### PR TITLE
[#22] 지도 검색 api 재구현

### DIFF
--- a/DaOnGil/.idea/deploymentTargetSelector.xml
+++ b/DaOnGil/.idea/deploymentTargetSelector.xml
@@ -8,6 +8,17 @@
       <SelectionState runConfigName="SplashActivity">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
+      <SelectionState runConfigName="SplashActivity (1)">
+        <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2024-07-28T02:27:14.967760Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=52004b4cb4f815a9" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/DaOnGil/.idea/other.xml
+++ b/DaOnGil/.idea/other.xml
@@ -180,17 +180,6 @@
           <option name="screenY" value="2400" />
         </PersistentDeviceSelectionData>
         <PersistentDeviceSelectionData>
-          <option name="api" value="31" />
-          <option name="brand" value="samsung" />
-          <option name="codename" value="q2q" />
-          <option name="id" value="q2q" />
-          <option name="manufacturer" value="Samsung" />
-          <option name="name" value="Galaxy Z Fold3" />
-          <option name="screenDensity" value="420" />
-          <option name="screenX" value="1768" />
-          <option name="screenY" value="2208" />
-        </PersistentDeviceSelectionData>
-        <PersistentDeviceSelectionData>
           <option name="api" value="34" />
           <option name="brand" value="samsung" />
           <option name="codename" value="q5q" />

--- a/DaOnGil/gradle/libs.versions.toml
+++ b/DaOnGil/gradle/libs.versions.toml
@@ -34,7 +34,7 @@ kotlin-serialization-plugin = "1.9.22"
 navigationSafeArgs = "2.7.7"
 coroutines-core = "1.7.3"
 javaxInject="1"
-playServicesLocation = "18.0.0"
+playServicesLocation = "21.3.0"
 
 [libraries]
 play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/adapter/ListSearchAdapter.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/adapter/ListSearchAdapter.kt
@@ -44,7 +44,7 @@ class ListSearchAdapter(
     private val sigunguList: MutableList<String> = mutableListOf()
     private val optionState: MutableMap<DisabilityType, Int> = HashMap()
 
-    fun submitList(newData: List<ListSearchUIModel>) {
+    fun submitList(newData: Set<ListSearchUIModel>) {
         val oldPlaceModels = allDataList.filterIsInstance<PlaceModel>()
         if (oldPlaceModels.isNotEmpty()) {
             allDataList.removeAll(oldPlaceModels)

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/bottomsheet/PlaceBottomSheet.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/bottomsheet/PlaceBottomSheet.kt
@@ -5,14 +5,14 @@ import android.view.View
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.bumptech.glide.Glide
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-import kr.tekit.lion.domain.model.MapSearchResult
 import kr.tekit.lion.presentation.R
 import kr.tekit.lion.presentation.databinding.PlaceBottomSheetBinding
 import kr.tekit.lion.presentation.main.adapter.DisabilityRVAdapter
+import kr.tekit.lion.presentation.main.model.MapPlaceModel
 
 class PlaceBottomSheet(
-    private val place: MapSearchResult,
-    private val onClick: (Int) -> Unit
+    private val place: MapPlaceModel,
+    private val onClick: (String) -> Unit
 ): BottomSheetDialogFragment(R.layout.place_bottom_sheet) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -27,13 +27,13 @@ class PlaceBottomSheet(
             }
 
             Glide.with(binding.thumbnailImg.context)
-                .load(place.image)
+                .load(place.placeImg)
                 .error(R.drawable.empty_view)
                 .placeholder(R.drawable.empty_view)
                 .into(binding.thumbnailImg)
 
-            textPlaceName.text = place.name
-            textAddr.text = place.address
+            textPlaceName.text = place.placeName
+            textAddr.text = place.placeAddr
 
             disabilityRv.adapter = adapter
             disabilityRv.layoutManager = LinearLayoutManager(
@@ -43,5 +43,4 @@ class PlaceBottomSheet(
             )
         }
     }
-
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/SearchListFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/SearchListFragment.kt
@@ -71,7 +71,7 @@ class SearchListFragment : Fragment(R.layout.fragment_search_list) {
                 viewModel.onSelectedArrange(it)
             })
 
-        val arr = ArrayList<ListSearchUIModel>()
+        val arr = mutableSetOf<ListSearchUIModel>()
         arr.add(CategoryModel)
         arr.add(AreaModel)
 

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/SearchListFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/SearchListFragment.kt
@@ -9,12 +9,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.GridLayoutManager
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
-import kr.tekit.lion.domain.model.ConnectError
-import kr.tekit.lion.domain.model.HttpError
-import kr.tekit.lion.domain.model.TimeoutError
-import kr.tekit.lion.domain.model.UnknownHostError
-import kr.tekit.lion.domain.model.onError
-import kr.tekit.lion.domain.model.onSuccess
 import kr.tekit.lion.presentation.R
 import kr.tekit.lion.presentation.databinding.FragmentSearchListBinding
 import kr.tekit.lion.presentation.ext.addOnScrollEndListener
@@ -26,7 +20,6 @@ import kr.tekit.lion.presentation.main.model.CategoryModel
 import kr.tekit.lion.presentation.main.model.DisabilityType
 import kr.tekit.lion.presentation.main.model.ListSearchUIModel
 import kr.tekit.lion.presentation.main.model.PlaceModel
-import kr.tekit.lion.presentation.main.model.toUiModel
 import kr.tekit.lion.presentation.main.vm.search.SearchListViewModel
 import kr.tekit.lion.presentation.main.vm.search.SharedViewModel
 
@@ -103,6 +96,11 @@ class SearchListFragment : Fragment(R.layout.fragment_search_list) {
                 }
             }
         }
+        repeatOnViewStarted {
+            sharedViewModel.sharedOptionState.collect{
+                viewModel.onChangeMapState(it)
+            }
+        }
 
         repeatOnViewStarted {
             sharedViewModel.tabState.collect{
@@ -132,7 +130,7 @@ class SearchListFragment : Fragment(R.layout.fragment_search_list) {
         }
 
         repeatOnViewStarted {
-            sharedViewModel.optionState.collect {
+            sharedViewModel.bottomSheetOptionState.collect {
                 mainAdapter.modifyOptionState(it)
             }
         }
@@ -146,9 +144,13 @@ class SearchListFragment : Fragment(R.layout.fragment_search_list) {
 
     private fun showBottomSheet(selectedOptions: List<Int>, disabilityType: DisabilityType) {
         CategoryBottomSheet(selectedOptions, disabilityType) { optionIds, optionNames ->
-            sharedViewModel.onSelectOption(optionIds, disabilityType)
+            sharedViewModel.onSelectOption(optionIds, disabilityType, optionNames)
             viewModel.onSelectOption(optionNames, disabilityType)
         }.show(parentFragmentManager, "bottomSheet")
+    }
+
+    fun updateData(data: Boolean) {
+        if (data) viewModel.onMapChanged(data)
     }
 }
 

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/SearchPlaceMainFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/SearchPlaceMainFragment.kt
@@ -79,6 +79,9 @@ class SearchPlaceMainFragment : Fragment(R.layout.fragment_search_place_main) {
     }
 
     private fun showFragment(fragment: Fragment) {
+        if (fragment is SearchListFragment) {
+            fragment.updateData(true)
+        }
         childFragmentManager.beginTransaction().apply {
             show(fragment)
             commit()

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/model/ListSearchUIModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/model/ListSearchUIModel.kt
@@ -1,6 +1,7 @@
 package kr.tekit.lion.presentation.main.model
 
 import kr.tekit.lion.domain.model.ListSearchResultList
+import kr.tekit.lion.domain.model.MapSearchResultList
 import kr.tekit.lion.presentation.R
 
 sealed class ListSearchUIModel(val id: Int)

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/model/MapPlaceModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/model/MapPlaceModel.kt
@@ -1,0 +1,26 @@
+package kr.tekit.lion.presentation.main.model
+
+import kr.tekit.lion.domain.model.MapSearchResultList
+
+data class MapPlaceModel(
+    val placeName: String,
+    val placeAddr: String,
+    val placeId: String,
+    val placeImg: String="",
+    val latitude: Double,
+    val longitude: Double,
+    val disability: List<String> = emptyList(),
+)
+
+fun MapSearchResultList.toUiModel(): List<MapPlaceModel> =
+    this.places.map {
+        MapPlaceModel(
+            placeName = it.name,
+            placeAddr = it.address,
+            placeId = it.placeId.toString(),
+            placeImg = it.image,
+            latitude = it.mapY,
+            longitude = it.mapX,
+            disability = it.disability,
+        )
+    }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/model/SharedOptionState.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/model/SharedOptionState.kt
@@ -1,0 +1,15 @@
+package kr.tekit.lion.presentation.main.model
+
+import java.util.TreeSet
+
+data class SharedOptionState(
+    val disabilityType: TreeSet<Long> = TreeSet(),
+    val detailFilter: TreeSet<Long> = TreeSet()
+){
+    fun clear(): SharedOptionState {
+        return this.copy(
+            disabilityType = TreeSet(),
+            detailFilter = TreeSet()
+        )
+    }
+}

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/vm/search/SearchListViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/vm/search/SearchListViewModel.kt
@@ -1,6 +1,5 @@
 package kr.tekit.lion.presentation.main.vm.search
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -119,8 +118,6 @@ class SearchListViewModel @Inject constructor(
         listOptionState.collect { listOption ->
             placeRepository.getSearchPlaceResultByList(listOption.toDomainModel())
                 .onSuccess { result ->
-                    Log.d("czxczas", "v place: $result")
-
                     _place.update { _place.value + result.toUiModel() }
                     if (result.isLastPage) _isLastPage.value = true
                 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/vm/search/SharedViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/vm/search/SharedViewModel.kt
@@ -3,13 +3,16 @@ package kr.tekit.lion.presentation.main.vm.search
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kr.tekit.lion.presentation.main.model.Category
 import kr.tekit.lion.presentation.main.model.DisabilityType
 import kr.tekit.lion.presentation.main.model.ElderlyPeople
 import kr.tekit.lion.presentation.main.model.HearingImpairment
 import kr.tekit.lion.presentation.main.model.InfantFamily
 import kr.tekit.lion.presentation.main.model.PhysicalDisability
+import kr.tekit.lion.presentation.main.model.SharedOptionState
 import kr.tekit.lion.presentation.main.model.VisualImpairment
+import java.util.TreeSet
 
 class SharedViewModel: ViewModel() {
     private val _physicalDisabilityOptions = MutableStateFlow<List<Int>>(emptyList())
@@ -27,14 +30,22 @@ class SharedViewModel: ViewModel() {
     private val _elderlyPersonOptions = MutableStateFlow<List<Int>>(emptyList())
     val elderlyPersonOptions get() = _elderlyPersonOptions.asStateFlow()
 
-    private val _optionState = MutableStateFlow<Map<DisabilityType, Int>>(emptyMap())
-    val optionState get() = _optionState.asStateFlow()
+    private val _bottomSheetOptionState = MutableStateFlow<Map<DisabilityType, Int>>(emptyMap())
+    val bottomSheetOptionState get() = _bottomSheetOptionState.asStateFlow()
+
+    private val _sharedOptionState = MutableStateFlow(SharedOptionState())
+    val sharedOptionState get() = _sharedOptionState.asStateFlow()
 
     private val _tabState = MutableStateFlow(Category.PLACE)
     val tabState get() = _tabState.asStateFlow()
 
-    fun onSelectOption(optionIds: List<Int>, type: DisabilityType) {
-        updateOptionState(type, optionIds.size)
+    fun onSelectOption(optionIds: List<Int>, type: DisabilityType, optionCodes: List<Long>) {
+        updateBottomSheetOptionState(type, optionIds.size)
+
+        val currentOptionState = _sharedOptionState.value
+        val updatedDisabilityTypes = TreeSet(currentOptionState.disabilityType)
+        val updatedDetailFilters = TreeSet(currentOptionState.detailFilter)
+
         when (type) {
             is PhysicalDisability -> {
                 _physicalDisabilityOptions.value = optionIds
@@ -52,23 +63,47 @@ class SharedViewModel: ViewModel() {
                 _elderlyPersonOptions.value = optionIds
             }
         }
+
+        when (type) {
+            is PhysicalDisability -> updatedDetailFilters.removeAll(PhysicalDisability.filterCodes)
+            is VisualImpairment -> updatedDetailFilters.removeAll(VisualImpairment.filterCodes)
+            is HearingImpairment -> updatedDetailFilters.removeAll(HearingImpairment.filterCodes)
+            is InfantFamily -> updatedDetailFilters.removeAll(InfantFamily.filterCodes)
+            is ElderlyPeople -> updatedDetailFilters.removeAll(ElderlyPeople.filterCodes)
+        }
+
+        if (optionCodes.isNotEmpty()) {
+            updatedDisabilityTypes.add(type.code)
+            updatedDetailFilters.addAll(optionCodes)
+        } else {
+            updatedDisabilityTypes.remove(type.code)
+        }
+
+        _sharedOptionState.update {
+            currentOptionState.copy(
+                disabilityType = updatedDisabilityTypes,
+                detailFilter = updatedDetailFilters,
+            )
+        }
     }
 
     fun onTabChanged(category: Category) {
         _tabState.value = category
     }
 
-    private fun updateOptionState(disabilityType: DisabilityType, cnt: Int) {
-        val currentOption = optionState.value.toMutableMap()
+    private fun updateBottomSheetOptionState(disabilityType: DisabilityType, cnt: Int) {
+        val currentOption = _bottomSheetOptionState.value.toMutableMap()
         currentOption[disabilityType] = cnt
-        _optionState.value = currentOption.toMap()
+        _bottomSheetOptionState.value = currentOption.toMap()
     }
 
     fun onClickResetIcon() {
-        _physicalDisabilityOptions.value = emptyList()
-        _hearingImpairmentOptions.value = emptyList()
-        _visualImpairmentOptions.value = emptyList()
-        _infantFamilyOptions.value = emptyList()
-        _elderlyPersonOptions.value = emptyList()
+        _physicalDisabilityOptions.update { emptyList() }
+        _hearingImpairmentOptions.update { emptyList() }
+        _visualImpairmentOptions.update { emptyList() }
+        _infantFamilyOptions.update { emptyList() }
+        _elderlyPersonOptions.update { emptyList() }
+        _bottomSheetOptionState.update { emptyMap() }
+        _sharedOptionState.update { SharedOptionState().clear() }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #21
-  #13 
- #10 
## 📝작업 내용

- 온갖 버그 투성이인 검색 완료했습니다. ㅠㅠㅠㅠ
- 두 개의 검색 화면에서 바텀 시트에 선택한 옵션을 유지하려고 하나의 ViewModel을 같이 썼는데 
  지도에서 사용하는 데이터랑 리스트 검색에서 사용하는 데이터가 달라서  하나에 관리하던 데이터를 나누려니까 머리 터지는줄 알았습니다 ㅎㅎ
  
## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)

https://github.com/user-attachments/assets/53a53093-18a5-43fe-a327-27a4756f5c40


https://github.com/user-attachments/assets/cfad3463-c7c7-41b5-9511-e0b06bf7f9d1



## 💬리뷰 요구사항(선택)
개선사항 👍 
- 추가로 프로그래스바, 바텀시트 디자인 나오면 적용하겠습니다.
- 지금 서버에서 이미지를 불러오니까 스크롤시 버벅임이 좀 있는데 시간이 좀 남으면 이 부분 좀 성능 개선 시도해보겠습니다.
- 이후 작업은 Gemini API 적용 시도해보겠습니다. (Gemini 자체가 아직 Chat GPT 처럼 Stable 된게 아니라 장담은 못함..ㅎㅎ)