### PR TITLE
[#27] 3차 리사이클러뷰 성능 개선

### DIFF
--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/SearchListFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/SearchListFragment.kt
@@ -62,7 +62,7 @@ class SearchListFragment : Fragment(R.layout.fragment_search_list) {
             onSelectSigungu = {
                 viewModel.onSelectedSigungu(it)
             }
-            )
+        )
 
         val rvLayoutManager = GridLayoutManager(requireContext(), 2)
         rvLayoutManager.spanSizeLookup = object : GridLayoutManager.SpanSizeLookup() {
@@ -74,33 +74,16 @@ class SearchListFragment : Fragment(R.layout.fragment_search_list) {
             }
         }
 
-        val noPlaceViewPool = RecyclerView.RecycledViewPool().apply {
-            setMaxRecycledViews(R.layout.item_no_place, 1)
-        }
-
-        val areaViewPool = RecyclerView.RecycledViewPool().apply {
-            setMaxRecycledViews(R.layout.item_list_search_area, 1)
-        }
-
-        val sigunguViewPool = RecyclerView.RecycledViewPool().apply {
-            setMaxRecycledViews(R.layout.item_list_search_sigungu, 1)
-        }
-
-        val categoryViewPool = RecyclerView.RecycledViewPool().apply {
-            setMaxRecycledViews(R.layout.item_list_search_category, 1)
+        val placeViewPool = RecyclerView.RecycledViewPool().apply {
+            setMaxRecycledViews(VIEW_TYPE_PLACE, 10)
         }
 
         with(binding.rvSearchResult) {
             adapter = mainAdapter
+            itemAnimator = null
             layoutManager = rvLayoutManager
 
-            setRecycledViewPool(noPlaceViewPool)
-            setRecycledViewPool(areaViewPool)
-            setRecycledViewPool(sigunguViewPool)
-            setRecycledViewPool(categoryViewPool)
-
-            itemAnimator = null
-
+            setRecycledViewPool(placeViewPool)
             addOnScrollEndListener {
                 val pageState = viewModel.isLastPage.value
                 if (pageState.not()) {

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/vm/search/SearchListViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/vm/search/SearchListViewModel.kt
@@ -183,7 +183,7 @@ class SearchListViewModel @Inject constructor(
         listOptionState.update { it.copy(category = category, page = 0) }
     }
 
-    fun modifyCategoryModel(optionState: Map<DisabilityType, Int>) {
+    fun modifyCategoryModel(optionState: Map<DisabilityType, Int>) = viewModelScope.launch((Dispatchers.IO)) {
         _uiState.update { uiState ->
             updateCategoryModel(uiState, optionState)
         }
@@ -209,7 +209,7 @@ class SearchListViewModel @Inject constructor(
         }
     }
 
-    private suspend fun loadPlaces() {
+    private suspend fun loadPlaces() = viewModelScope.launch((Dispatchers.IO)) {
         listOptionState.collect { listOption ->
             placeRepository.getSearchPlaceResultByList(listOption.toDomainModel())
                 .onSuccess { result ->
@@ -238,7 +238,7 @@ class SearchListViewModel @Inject constructor(
         }
     }
 
-    private suspend fun reloadPlace() = viewModelScope.launch {
+    private suspend fun reloadPlace() = viewModelScope.launch(Dispatchers.IO) {
         clearPlace()
         listOptionState.take(1).collect { listOption ->
             placeRepository.getSearchPlaceResultByList(listOption.toDomainModel())
@@ -257,18 +257,18 @@ class SearchListViewModel @Inject constructor(
         }
     }
 
-    private fun clearPlace() {
+    private fun clearPlace() = viewModelScope.launch(Dispatchers.IO) {
         _uiState.update { uiState -> uiState.filterNot { it is PlaceModel } }
     }
 
-    fun onSelectedArea(areaName: String){
+    fun onSelectedArea(areaName: String) {
         clearPlace()
         val areaCode = areaCode.value.findAreaCode(areaName) ?: ""
         listOptionState.update { it.copy(areaCode = areaCode) }
         updateSigunguModel(areaCode)
     }
 
-    private fun updateSigunguModel(areaCode: String) = viewModelScope.launch(Dispatchers.IO){
+    private fun updateSigunguModel(areaCode: String) = viewModelScope.launch(Dispatchers.IO) {
         val sigunguList = sigunguCodeRepository.getAllSigunguCode(areaCode)
         sigunguCode.update { sigunguList }
 
@@ -298,13 +298,14 @@ class SearchListViewModel @Inject constructor(
     fun onSelectedSigungu(sigunguName: String) {
         val sigunguCode = sigunguCode.value.findSigunguCode(sigunguName)
         listOptionState.update { it.copy(sigunguCode = sigunguCode, page = 0) }
-
-        _uiState.update { uiState ->
-            uiState.map { uiModel ->
-                if (uiModel is SigunguModel) {
-                    uiModel.copy(selectedSigungu = sigunguName)
-                } else {
-                    uiModel
+        viewModelScope.launch((Dispatchers.IO)) {
+            _uiState.update { uiState ->
+                uiState.map { uiModel ->
+                    if (uiModel is SigunguModel) {
+                        uiModel.copy(selectedSigungu = sigunguName)
+                    } else {
+                        uiModel
+                    }
                 }
             }
         }
@@ -317,12 +318,14 @@ class SearchListViewModel @Inject constructor(
     private suspend fun loadAreaCodes() {
         val areaInfoList = areaCodeRepository.getAllAreaCodes()
         areaCode.update { areaInfoList }
-        _uiState.update { uiStateList ->
-            uiStateList.map { uiModel ->
-                if (uiModel is AreaModel) {
-                    uiModel.copy(areaInfoList.getAllAreaName())
-                } else {
-                    uiModel
+        viewModelScope.launch((Dispatchers.IO)) {
+            _uiState.update { uiStateList ->
+                uiStateList.map { uiModel ->
+                    if (uiModel is AreaModel) {
+                        uiModel.copy(areaInfoList.getAllAreaName())
+                    } else {
+                        uiModel
+                    }
                 }
             }
         }
@@ -332,7 +335,7 @@ class SearchListViewModel @Inject constructor(
         mapChanged.emit(state)
     }
 
-    fun onChangeMapState(state: SharedOptionState) {
+    fun onChangeMapState(state: SharedOptionState) = viewModelScope.launch(Dispatchers.IO) {
         listOptionState.update {
             if (state.detailFilter.isEmpty()) {
                 it.copy(


### PR DESCRIPTION
## #️⃣연관된 이슈

- #27 

## 📝작업 내용

- 뷰홀더 내용이 변경될 때 화면이 깜빡이는 현상 수정
- 선택된 옵션을 계산할 떄 백그라운드 스레드에서 수행하도록 수정
- ViewModel 로직들을 함수로 분리

## 스크린샷 (선택)

https://github.com/user-attachments/assets/056cd89d-948e-4fd7-9237-71cf42947f1b

## 💬리뷰 요구사항(선택)

- DiffUtil은 아이템이 변경될  때 default로 애니메이션을 동작하게 합니다.
  이 애니메이션 때문에 화면 깜빡임이 발생했는데용 이런 애니메이션이 오히려 렌더링 더 무겁게 만드는 원인이 됩니다.
  메소드를 통해 이 애니메이션을 제거할 수 있는데 요 부분 마킹해놓겠습니다.

- ViewModel에서 여러가지 옵션에 대한 계산 로직을 작성해놨는데요 기존에는 그냥 ViewModelScope.launch로 구현해놨습니다.
   이 경우, 아마 메인 스레드(UI Thread)에서 계산을 할탠데 이런 계산 로직은 백그라운드 스레드에서 하는 것이 훨씬 안정적일 것 같습니다.
   그래서 Dispatchers.IO 디스패처를 적용해서 백그라운드 스레드에서 계산하도록 변경했습니다. 

- 아직 만족할 만큼의 성능 개선은 이루어지지 않았지만 서버분들이 에러 코드를 작성해주셔서 우선 네트워크 에러처리 처리 후 
  다시 개선작업 하겠습니다람쥐~
