### PR TITLE
[#49] 응급지원 메인 화면 구현 및 activity 연결

### DIFF
--- a/DaOnGil/presentation/src/main/AndroidManifest.xml
+++ b/DaOnGil/presentation/src/main/AndroidManifest.xml
@@ -8,6 +8,12 @@
 
     <application android:theme="@style/Base.Theme.DaOnGil">
         <activity
+            android:name=".emergency.PharmacyMapActivity"
+            android:exported="false" />
+        <activity
+            android:name=".emergency.EmergencyMapActivity"
+            android:exported="false" />
+        <activity
             android:name=".concerntype.ConcernTypeActivity"
             android:exported="false" />
         <activity

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/emergency/EmergencyMapActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/emergency/EmergencyMapActivity.kt
@@ -1,0 +1,12 @@
+package kr.tekit.lion.presentation.emergency
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import kr.tekit.lion.presentation.R
+
+class EmergencyMapActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_emergency_map)
+    }
+}

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/emergency/PharmacyMapActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/emergency/PharmacyMapActivity.kt
@@ -1,0 +1,12 @@
+package kr.tekit.lion.presentation.emergency
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import kr.tekit.lion.presentation.R
+
+class PharmacyMapActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_pharmacy_map)
+    }
+}

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/emergency/adapter/EmergencyBottomAdapter.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/emergency/adapter/EmergencyBottomAdapter.kt
@@ -1,0 +1,86 @@
+package kr.tekit.lion.presentation.emergency.adapter
+
+import android.graphics.Color
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import kr.tekit.lion.presentation.R
+import kr.tekit.lion.presentation.databinding.ItemEmergencyBottomBinding
+
+class EmergencyBottomAdapter(
+    // private val emergencyMapInfoList: List<EmergencyMapInfo>,
+    private val itemClickListener: (Int) -> Unit
+) : RecyclerView.Adapter<EmergencyBottomAdapter.EmergencyBottomViewHolder>() {
+
+    class EmergencyBottomViewHolder(
+        private val binding: ItemEmergencyBottomBinding,
+        private val itemClickListener: (Int) -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+        init {
+            binding.root.setOnClickListener {
+                itemClickListener.invoke(absoluteAdapterPosition)
+            }
+        }
+
+        /*fun bind(item: EmergencyMapInfo) {
+            with(binding) {
+                if (item.emergencyType == "hospital") {
+                    emergencyBottomImage.setImageResource(R.drawable.emergency_bottom_img)
+                    emergencyBedLayout.visibility = View.VISIBLE
+                    emergencyName.text = item.hospitalList?.hospitalName
+                    emergencyAddress.text = item.hospitalList?.hospitalAddress
+                    emergencyCall.text = item.hospitalList?.emergencyTel
+                    emergencyBed.text =
+                        item.hospitalList?.emergencyCount.toString() + " / " + item.hospitalList?.emergencyAllCount.toString()
+
+                    item.hospitalList?.emergencyBed?.let { it ->
+                        val emergencyBedIcon = emergencyBedIcon
+
+                        val drawable = emergencyBedIcon.drawable
+                        if (drawable != null) {
+                            val color = when {
+                                it >= 80 -> Color.parseColor("#008000") // Green
+                                it >= 50 -> Color.parseColor("#FFFF00") // Yellow
+                                else -> Color.parseColor("#FF0000") // Red
+                            }
+                            drawable.setTint(color)
+                        }
+                    }
+                }
+
+                if (item.emergencyType == "aed") {
+                    emergencyBottomImage.setImageResource(R.drawable.aed_bottom_img)
+                    emergencyBedLayout.visibility = View.GONE
+                    emergencyName.text = item.aedList?.aedName
+                    emergencyAddress.text = item.aedList?.aedAdress
+                    emergencyCall.text = item.aedList?.aedTel
+                }
+            }
+        }*/
+
+        fun bind(){
+
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): EmergencyBottomViewHolder {
+        return EmergencyBottomViewHolder(
+            ItemEmergencyBottomBinding.inflate(
+                LayoutInflater.from(parent.context), parent, false
+            ), itemClickListener
+        )
+
+    }
+
+    override fun getItemCount(): Int {
+        // return emergencyMapInfoList.size
+        return 0
+    }
+
+    override fun onBindViewHolder(holder: EmergencyBottomViewHolder, position: Int) {
+        // holder.bind(emergencyMapInfoList[position])
+        holder.bind()
+    }
+
+}

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/emergency/fragment/EmergencyAreaDialog.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/emergency/fragment/EmergencyAreaDialog.kt
@@ -1,0 +1,107 @@
+package kr.tekit.lion.presentation.emergency.fragment
+
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.os.Bundle
+import android.view.View
+import android.widget.ArrayAdapter
+import androidx.annotation.ArrayRes
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.activityViewModels
+import kr.tekit.lion.presentation.R
+import kr.tekit.lion.presentation.databinding.DialogEmergencyAreaBinding
+
+class EmergencyAreaDialog(
+
+) : DialogFragment(R.layout.dialog_emergency_area) {
+
+    // private val viewModel: EmergencyMapViewModel by activityViewModels()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        val binding = DialogEmergencyAreaBinding.bind(view)
+
+        dialog?.window?.setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+
+        with(binding) {
+            emergencyAreaNegative.setOnClickListener {
+                emergencyAreaSelected.setText("")
+                emergencyDetailAreaSelected.setText("")
+                dismiss()
+            }
+
+            emergencyAreaPositive.setOnClickListener {
+                val areaDetail =
+                    if (emergencyDetailAreaSelected.text.toString() == "세종특별자치시") null else emergencyDetailAreaSelected.text.toString()
+                // viewModel.setArea(emergencyAreaSelected.text.toString(), areaDetail)
+                emergencyAreaSelected.setText("")
+                emergencyDetailAreaSelected.setText("")
+                dismiss()
+            }
+
+            val areas = resources.getStringArray(R.array.areas)
+
+            val areaAdapter = ArrayAdapter(
+                requireContext(),
+                android.R.layout.simple_dropdown_item_1line,
+                areas
+            )
+
+            emergencyAreaSelected.setAdapter(areaAdapter)
+
+            emergencyAreaSelected.setOnItemClickListener { adapterView, view, position, id ->
+                val selectedArea = adapterView.getItemAtPosition(position).toString()
+                // 선택된 지역의 영문 리소스 이름을 매핑합니다.
+                val areaNameInEnglish = mapAreaNameToEnglish(selectedArea)
+
+                @ArrayRes
+                val detailAreasResourceId = resources.getIdentifier(
+                    "area_details_$areaNameInEnglish",
+                    "array",
+                    context?.packageName
+                )
+
+                val detailAreas = resources.getStringArray(detailAreasResourceId)
+
+                val areaDetailAdapter = ArrayAdapter(
+                    requireContext(),
+                    android.R.layout.simple_dropdown_item_1line,
+                    detailAreas
+                )
+                emergencyDetailAreaSelected.setAdapter(areaDetailAdapter)
+                emergencyDetailAreaSelected.setText("")
+                emergencyAreaPositive.isEnabled = false
+                emergencyDetailAreaLayout.visibility = View.VISIBLE
+            }
+
+            emergencyDetailAreaSelected.setOnItemClickListener { adapterView, view, i, l ->
+                emergencyAreaPositive.isEnabled = true
+            }
+
+        }
+    }
+
+    private fun mapAreaNameToEnglish(areaName: String): String {
+        return when (areaName) {
+            "서울특별시" -> "seoul"
+            "부산광역시" -> "busan"
+            "대구광역시" -> "daegu"
+            "인천광역시" -> "incheon"
+            "광주광역시" -> "gwangju"
+            "대전광역시" -> "daejeon"
+            "울산광역시" -> "ulsan"
+            "세종특별자치시" -> "sejong"
+            "경기도" -> "gyeonggi"
+            "강원특별자치도" -> "gangwon"
+            "충청북도" -> "chungbuk"
+            "충청남도" -> "chungnam"
+            "전북특별자치도" -> "jeonbuk"
+            "전라남도" -> "jeonnam"
+            "경상북도" -> "gyeongbuk"
+            "경상남도" -> "gyeongnam"
+            "제주특별자치도" -> "jeju"
+            else -> ""
+        }
+    }
+}

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/emergency/fragment/EmergencyBottomSheet.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/emergency/fragment/EmergencyBottomSheet.kt
@@ -1,0 +1,47 @@
+package kr.tekit.lion.presentation.emergency.fragment
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import kr.tekit.lion.presentation.R
+import kr.tekit.lion.presentation.databinding.EmergencyBottomSheetLayoutBinding
+import kr.tekit.lion.presentation.emergency.adapter.EmergencyBottomAdapter
+
+class EmergencyBottomSheet(
+    private val binding: EmergencyBottomSheetLayoutBinding,
+    // private val emergencyMapInfoList: List<EmergencyMapInfo>
+) {
+
+    /*private val emergencyBottomAdapter: EmergencyBottomAdapter by lazy {
+        EmergencyBottomAdapter(emergencyMapInfoList,
+            itemClickListener = { position ->
+                val context: Context = binding.root.context
+                val intent = Intent(context, EmergencyInfoActivity::class.java)
+                intent.putExtra("infoType", emergencyMapInfoList[position].emergencyType)
+                intent.putExtra("data", emergencyMapInfoList[position])
+                intent.putExtra("id", emergencyMapInfoList[position].emergencyId)
+                context.startActivity(intent)
+            }
+        )
+    }*/
+
+    fun setRecyclerView(){
+        with(binding){
+            /*emergencyBottomRv.adapter = emergencyBottomAdapter
+            emergencyBottomAdapter.notifyDataSetChanged()*/
+        }
+    }
+
+    fun recyclerViewTopButton() {
+        with(binding){
+            emergencyBottomSheetHead.setOnClickListener {
+                emergencyBottomRv.scrollToPosition(0)
+            }
+        }
+    }
+
+}

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/EmergencyMainFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/EmergencyMainFragment.kt
@@ -1,14 +1,29 @@
 package kr.tekit.lion.presentation.main.fragment
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.View
 import kr.tekit.lion.presentation.R
+import kr.tekit.lion.presentation.databinding.FragmentEmergencyMainBinding
+import kr.tekit.lion.presentation.emergency.EmergencyMapActivity
+import kr.tekit.lion.presentation.emergency.PharmacyMapActivity
 
 class EmergencyMainFragment : Fragment(R.layout.fragment_emergency_main) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        val binding = FragmentEmergencyMainBinding.bind(view)
+
+        binding.emrAedCard.setOnClickListener {
+            val intent = Intent(requireActivity(), EmergencyMapActivity::class.java)
+            startActivity(intent)
+        }
+
+        binding.pharmacyCard.setOnClickListener {
+            val intent = Intent(requireActivity(), PharmacyMapActivity::class.java)
+            startActivity(intent)
+        }
     }
 }

--- a/DaOnGil/presentation/src/main/res/layout/activity_emergency_map.xml
+++ b/DaOnGil/presentation/src/main/res/layout/activity_emergency_map.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbarEmergencyMap"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/background_color"
+            android:minHeight="?attr/actionBarSize"
+            app:navigationIcon="@drawable/back_icon">
+
+            <TextView
+                android:id="@+id/titleEmergencyMap"
+                style="@style/Theme.Toolbar.Title"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/text_emergency_aed" />
+
+        </com.google.android.material.appbar.MaterialToolbar>
+
+        <com.google.android.material.progressindicator.LinearProgressIndicator
+            android:id="@+id/emergencyMapProgressBar"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:indicatorColor="@color/primary"
+            android:progress="20"
+            app:trackColor="@color/background_color"/>
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+
+
+        <com.google.android.material.card.MaterialCardView
+            android:id="@+id/emergencyMapAreaButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:layout_marginTop="@dimen/margin_big2"
+            android:backgroundTint="@color/item_background"
+            app:cardCornerRadius="50dp"
+            app:cardElevation="10dp"
+            app:strokeColor="@color/primary_disabled">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="horizontal"
+                android:paddingLeft="@dimen/margin_big4"
+                android:paddingTop="@dimen/margin_big4"
+                android:paddingRight="@dimen/margin_small1"
+                android:paddingBottom="@dimen/margin_big4">
+
+                <ImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:src="@drawable/emergency_map_icon" />
+
+                <TextView
+                    android:id="@+id/emergencyMapArea"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_marginStart="@dimen/margin_small1"
+                    android:fontFamily="@font/pretendard_medium"
+                    android:textColor="@color/text_secondary"
+                    android:textSize="@dimen/font_big3" />
+
+                <ImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:src="@drawable/ic_chevron_right_24px" />
+
+            </LinearLayout>
+
+        </com.google.android.material.card.MaterialCardView>
+
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/map"
+            android:name="com.naver.maps.map.MapFragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+    </FrameLayout>
+
+    <include
+        android:id="@+id/emergencyBottomSheet"
+        layout="@layout/emergency_bottom_sheet_layout"
+        app:layout_anchor="@+id/emergencyMapAreaButton"
+        app:layout_anchorGravity="bottom"/>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/DaOnGil/presentation/src/main/res/layout/activity_pharmacy_map.xml
+++ b/DaOnGil/presentation/src/main/res/layout/activity_pharmacy_map.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".emergency.PharmacyMapActivity">
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/DaOnGil/presentation/src/main/res/layout/dialog_emergency_area.xml
+++ b/DaOnGil/presentation/src/main/res/layout/dialog_emergency_area.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/background_radius_10"
+    android:backgroundTint="@color/background_color"
+    android:gravity="center"
+    android:minWidth="300dp"
+    android:orientation="vertical"
+    android:padding="@dimen/margin_basic">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:fontFamily="@font/pretendard_semibold"
+        android:gravity="center"
+        android:minHeight="50dp"
+        android:text="@string/title_emergency_area_dialog"
+        android:textColor="@color/text_primary"
+        android:textSize="@dimen/font_big1" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:minHeight="40dp"
+        android:text="@string/subtitle_emergency_area_dialog"
+        android:textColor="@color/text_secondary"
+        android:textSize="@dimen/font_big3" />
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_small2"
+        android:orientation="vertical">
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/emergencyAreaLayout"
+            style="@style/area_auto_complete_text_input_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="시도 선택"
+            android:textColorHint="@color/select_area_text">
+
+            <AutoCompleteTextView
+                android:id="@+id/emergencyAreaSelected"
+                style="@style/area_auto_complete_text_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="none" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/emergencyDetailAreaLayout"
+            style="@style/area_auto_complete_text_input_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="시군구 선택"
+            android:textColorHint="@color/select_area_text"
+            android:visibility="gone">
+
+            <AutoCompleteTextView
+                android:id="@+id/emergencyDetailAreaSelected"
+                style="@style/area_auto_complete_text_view"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="none" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/emergencyAreaNegative"
+            android:layout_width="0dp"
+            android:layout_height="48dp"
+            android:layout_marginEnd="@dimen/margin_big4"
+            android:layout_weight="1"
+            android:background="@drawable/background_radius_5"
+            android:fontFamily="@font/pretendard_medium"
+            android:text="취소"
+            android:textSize="@dimen/font_big3"
+            android:textColor="@color/black"
+            app:backgroundTint="@color/button_secondary" />
+
+        <Button
+            android:id="@+id/emergencyAreaPositive"
+            android:layout_width="0dp"
+            android:layout_height="48dp"
+            android:layout_weight="1"
+            android:background="@drawable/background_radius_5"
+            android:fontFamily="@font/pretendard_semibold"
+            android:text="적용하기"
+            android:textColor="@color/color_text_emergency_area"
+            android:textSize="@dimen/font_big3"
+            android:backgroundTint="@color/color_button_emergency_area"
+            android:enabled="false"/>
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/DaOnGil/presentation/src/main/res/layout/emergency_bottom_sheet_layout.xml
+++ b/DaOnGil/presentation/src/main/res/layout/emergency_bottom_sheet_layout.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/emergencyBottomSheetLayout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:background="@drawable/bottom_sheet_background"
+    android:backgroundTint="@color/navi_background"
+    tools:context=".emergency.fragment.EmergencyBottomSheet"
+    app:behavior_peekHeight="40dp"
+    android:clickable="true"
+    android:focusable="true"
+    app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
+
+    <ImageView
+        android:id="@+id/emergencyBottomSheetHead"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:src="@drawable/bottom_sheet_head" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/emergencyBottomRv"
+        android:layout_marginTop="@dimen/margin_small1"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/margin_basic"
+        android:paddingEnd="@dimen/margin_basic"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        tools:listitem="@layout/item_emergency_bottom"
+        tools:itemCount="10"/>
+
+
+</LinearLayout>

--- a/DaOnGil/presentation/src/main/res/layout/item_emergency_bottom.xml
+++ b/DaOnGil/presentation/src/main/res/layout/item_emergency_bottom.xml
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_marginTop="@dimen/margin_basic">
+
+        <ImageView
+            android:id="@+id/emergencyBottomImage"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            android:scaleType="centerCrop" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/margin_big4"
+            android:orientation="vertical"
+            android:layout_gravity="center_vertical">
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/emergencyName"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_small2"
+                    android:fontFamily="@font/pretendard_semibold"
+                    android:textColor="@color/text_primary"
+                    android:textSize="@dimen/font_big3" />
+
+                <TextView
+                    android:id="@+id/emergencyDistance"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginStart="@dimen/margin_small1"
+                    android:layout_marginTop="@dimen/margin_small2"
+                    android:fontFamily="@font/pretendard_semibold"
+                    android:textColor="@color/emergency_color"
+                    android:textSize="@dimen/font_small1" />
+
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/emergencyAddress"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_small2"
+                android:drawableStart="@drawable/address_icon"
+                android:drawablePadding="@dimen/margin_small2"
+                android:drawableTint="@color/text_quaternary"
+                android:ellipsize="end"
+                android:fontFamily="@font/pretendard_regular"
+                android:maxLines="1"
+                android:textColor="@color/text_secondary"
+                android:textSize="@dimen/font_small1" />
+
+            <TextView
+                android:id="@+id/emergencyCall"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_small2"
+                android:drawableStart="@drawable/call_icon"
+                android:drawablePadding="@dimen/margin_small2"
+                android:drawableTint="@color/text_quaternary"
+                android:fontFamily="@font/pretendard_regular"
+                android:textColor="@color/text_secondary"
+                android:textSize="@dimen/font_small1" />
+
+            <LinearLayout
+                android:id="@+id/emergencyBedLayout"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:visibility="gone">
+
+                <ImageView
+                    android:id="@+id/emergencyBedIcon"
+                    android:layout_width="15dp"
+                    android:layout_height="15dp"
+                    android:src="@drawable/emergency_radius"
+                    android:tint="@color/primary"
+                    android:layout_gravity="center_vertical"/>
+
+                <TextView
+                    android:id="@+id/emergencyBed"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_small2"
+                    android:fontFamily="@font/pretendard_regular"
+                    android:layout_marginStart="@dimen/margin_small1"
+                    android:textColor="@color/text_secondary"
+                    android:textSize="@dimen/font_small1" />
+            </LinearLayout>
+
+
+        </LinearLayout>
+    </LinearLayout>
+
+    <com.google.android.material.divider.MaterialDivider
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/margin_big3"
+        app:dividerColor="@color/primary_disabled"
+        app:dividerThickness="2dp" />
+
+</LinearLayout>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #49 

## 📝작업 내용

- 응급지원 메인 화면에서 연결되는 activity들 구현 했습니다.
- 먼저 작업을 진행할 emergencyMapActivity 관련된 것들은 다 구현했고, pharamacyMapActivity는 추후 더 진행하겠습니다.

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 💬리뷰 요구사항(선택)

- 일단 UI만 한거라서 바로 머지하겠습니다 !
