### PR TITLE
[#59] 내 일정 목록 UI api 연결

### DIFF
--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/datasource/PlanDataSource.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/datasource/PlanDataSource.kt
@@ -1,0 +1,24 @@
+package kr.tekit.lion.data.datasource
+
+import kr.tekit.lion.data.common.execute
+import kr.tekit.lion.data.service.PlanService
+import kr.tekit.lion.domain.exception.Result
+import kr.tekit.lion.domain.model.schedule.MyElapsedSchedules
+import kr.tekit.lion.domain.model.schedule.MyUpcomingSchedules
+import javax.inject.Inject
+
+internal class PlanDataSource @Inject constructor(
+    private val planService: PlanService
+) {
+    companion object {
+        private const val PAGE_SIZE = 10
+    }
+
+    suspend fun getMyUpcomingScheduleList(page: Int): Result<MyUpcomingSchedules> = execute {
+        planService.getMyUpcomingScheduleList(PAGE_SIZE, page).toDomainModel()
+    }
+
+    suspend fun getMyElapsedScheduleList(page: Int): Result<MyElapsedSchedules> = execute {
+        planService.getMyElapsedScheduleList(PAGE_SIZE, page).toDomainModel()
+    }
+}

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/di/NetworkModule.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/di/NetworkModule.kt
@@ -15,6 +15,7 @@ import kr.tekit.lion.data.service.KorWithService
 import kr.tekit.lion.data.service.MemberService
 import kr.tekit.lion.data.service.NaverMapService
 import kr.tekit.lion.data.service.PlaceService
+import kr.tekit.lion.data.service.PlanService
 import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
@@ -138,5 +139,11 @@ internal object NetworkModule {
             .add(LocalDate::class.java, Rfc3339DateJsonAdapter().nullSafe())
             .add(KotlinJsonAdapterFactory())
             .build()
+    }
+
+    @Provides
+    @Singleton
+    fun providePlanService(retrofit: Retrofit): PlanService {
+        return retrofit.create(PlanService::class.java)
     }
 }

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/di/RepositoryModule.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/di/RepositoryModule.kt
@@ -12,6 +12,7 @@ import kr.tekit.lion.data.repository.KorWithRepositoryImpl
 import kr.tekit.lion.data.repository.MemberRepositoryImpl
 import kr.tekit.lion.data.repository.NaverMapRepositoryImpl
 import kr.tekit.lion.data.repository.PlaceRepositoryImpl
+import kr.tekit.lion.data.repository.PlanRepositoryImpl
 import kr.tekit.lion.data.repository.RecentlySearchKeywordRepositoryImpl
 import kr.tekit.lion.data.repository.SigunguCodeRepositoryImpl
 import kr.tekit.lion.domain.repository.AppThemeRepository
@@ -22,6 +23,7 @@ import kr.tekit.lion.domain.repository.KorWithRepository
 import kr.tekit.lion.domain.repository.MemberRepository
 import kr.tekit.lion.domain.repository.NaverMapRepository
 import kr.tekit.lion.domain.repository.PlaceRepository
+import kr.tekit.lion.domain.repository.PlanRepository
 import kr.tekit.lion.domain.repository.RecentlySearchKeywordRepository
 import kr.tekit.lion.domain.repository.SigunguCodeRepository
 
@@ -60,4 +62,6 @@ internal interface RepositoryModule {
     @Binds
     fun bindNaverMapRepository(naverMapRepositoryImpl: NaverMapRepositoryImpl): NaverMapRepository
 
+    @Binds
+    fun bindPlanRepository(planRepositoryImpl: PlanRepositoryImpl): PlanRepository
 }

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleElapsed/Data.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleElapsed/Data.kt
@@ -1,0 +1,12 @@
+package kr.tekit.lion.data.dto.response.plan.myScheduleElapsed
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class Data(
+    val planResList: List<PlanRes>,
+    val pageNo: Int,
+    val pageSize: Int,
+    val totalPages: Int,
+    val last: Boolean,
+)

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleElapsed/MyElapsedResponse.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleElapsed/MyElapsedResponse.kt
@@ -1,0 +1,28 @@
+package kr.tekit.lion.data.dto.response.plan.myScheduleElapsed
+
+import com.squareup.moshi.JsonClass
+import kr.tekit.lion.domain.model.schedule.MyElapsedScheduleInfo
+import kr.tekit.lion.domain.model.schedule.MyElapsedSchedules
+
+@JsonClass(generateAdapter = true)
+data class MyElapsedResponse(
+    val code: Int,
+    val message: String,
+    val data: Data,
+) {
+    fun toDomainModel(): MyElapsedSchedules {
+        return MyElapsedSchedules(
+            myElapsedScheduleList = data.planResList.map {
+                MyElapsedScheduleInfo(
+                    planId = it.planId,
+                    title = it.title,
+                    startDate = it.startDate,
+                    endDate = it.endDate,
+                    imageUrl = it.imageUrl ?: "",
+                    hasReview = it.hasReview
+                )
+            },
+            last = data.last
+        )
+    }
+}

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleElapsed/PlanRes.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleElapsed/PlanRes.kt
@@ -1,0 +1,13 @@
+package kr.tekit.lion.data.dto.response.plan.myScheduleElapsed
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class PlanRes(
+    val planId: Long,
+    val title: String,
+    val startDate: String,
+    val endDate: String,
+    val imageUrl: String?,
+    val hasReview: Boolean,
+)

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleUpcoming/Data.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleUpcoming/Data.kt
@@ -1,0 +1,12 @@
+package kr.tekit.lion.data.dto.response.plan.myScheduleUpcoming
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class Data(
+    val planResList: List<PlanRes>,
+    val pageNo: Int,
+    val pageSize: Int,
+    val totalPages: Int,
+    val last: Boolean,
+)

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleUpcoming/MyUpcomingsResponse.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleUpcoming/MyUpcomingsResponse.kt
@@ -1,0 +1,29 @@
+package kr.tekit.lion.data.dto.response.plan.myScheduleUpcoming
+
+import com.squareup.moshi.JsonClass
+import kr.tekit.lion.domain.model.schedule.MyUpcomingScheduleInfo
+import kr.tekit.lion.domain.model.schedule.MyUpcomingSchedules
+
+@JsonClass(generateAdapter = true)
+data class MyUpcomingsResponse(
+    val code: Int,
+    val message: String,
+    val data: Data,
+) {
+    fun toDomainModel(): MyUpcomingSchedules {
+        return MyUpcomingSchedules(
+            myUpcomingScheduleList = this.data.planResList.map {
+                MyUpcomingScheduleInfo(
+                    planId = it.planId,
+                    title = it.title,
+                    startDate = it.startDate,
+                    endDate = it.endDate,
+                    imageUrl = it.imageUrl ?: "",
+                    //remainDate = it.remainDate
+                    remainDate = "D-1"
+                )
+            },
+            last = data.last
+        )
+    }
+}

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleUpcoming/PlanRes.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleUpcoming/PlanRes.kt
@@ -1,0 +1,13 @@
+package kr.tekit.lion.data.dto.response.plan.myScheduleUpcoming
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+data class PlanRes(
+    val planId: Long,
+    val title: String,
+    val startDate: String,
+    val endDate: String,
+    val imageUrl: String?,
+    // val remainDate: String,
+)

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/repository/PlanRepositoryImpl.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/repository/PlanRepositoryImpl.kt
@@ -1,0 +1,20 @@
+package kr.tekit.lion.data.repository
+
+import kr.tekit.lion.data.datasource.PlanDataSource
+import kr.tekit.lion.domain.exception.Result
+import kr.tekit.lion.domain.model.schedule.MyElapsedSchedules
+import kr.tekit.lion.domain.model.schedule.MyUpcomingSchedules
+import kr.tekit.lion.domain.repository.PlanRepository
+import javax.inject.Inject
+
+internal class PlanRepositoryImpl @Inject constructor(
+    private val planDataSource: PlanDataSource
+) : PlanRepository {
+    override suspend fun getMyUpcomingScheduleList(page: Int): Result<MyUpcomingSchedules> {
+        return planDataSource.getMyUpcomingScheduleList(page)
+    }
+
+    override suspend fun getMyElapsedScheduleList(page: Int): Result<MyElapsedSchedules> {
+        return planDataSource.getMyElapsedScheduleList(page)
+    }
+}

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/service/PlanService.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/service/PlanService.kt
@@ -1,0 +1,23 @@
+package kr.tekit.lion.data.service
+
+
+import kr.tekit.lion.data.dto.response.plan.myScheduleElapsed.MyElapsedResponse
+import kr.tekit.lion.data.dto.response.plan.myScheduleUpcoming.MyUpcomingsResponse
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface PlanService {
+    // 다가오는 일정 목록
+    @GET("plan/my/not-complete")
+    suspend fun getMyUpcomingScheduleList(
+        @Query("size") size: Int,
+        @Query("page") page: Int
+    ): MyUpcomingsResponse
+
+    // 다녀온 일정 목록
+    @GET("plan/my/complete")
+    suspend fun getMyElapsedScheduleList(
+        @Query("size") size: Int,
+        @Query("page") page: Int
+    ): MyElapsedResponse
+}

--- a/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/model/schedule/MyElapsedScheduleInfo.kt
+++ b/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/model/schedule/MyElapsedScheduleInfo.kt
@@ -1,0 +1,10 @@
+package kr.tekit.lion.domain.model.schedule
+
+data class MyElapsedScheduleInfo(
+    val planId: Long,
+    val title: String,
+    val startDate: String,
+    val endDate: String,
+    val imageUrl: String,
+    val hasReview: Boolean,
+)

--- a/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/model/schedule/MyElapsedSchedules.kt
+++ b/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/model/schedule/MyElapsedSchedules.kt
@@ -1,0 +1,6 @@
+package kr.tekit.lion.domain.model.schedule
+
+data class MyElapsedSchedules(
+    val myElapsedScheduleList: List<MyElapsedScheduleInfo>,
+    val last: Boolean,
+)

--- a/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/model/schedule/MyUpcomingScheduleInfo.kt
+++ b/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/model/schedule/MyUpcomingScheduleInfo.kt
@@ -1,0 +1,10 @@
+package kr.tekit.lion.domain.model.schedule
+
+data class MyUpcomingScheduleInfo(
+    val planId: Long,
+    val title: String,
+    val startDate: String,
+    val endDate: String,
+    val imageUrl: String,
+    val remainDate: String,
+)

--- a/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/model/schedule/MyUpcomingSchedules.kt
+++ b/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/model/schedule/MyUpcomingSchedules.kt
@@ -1,0 +1,6 @@
+package kr.tekit.lion.domain.model.schedule
+
+data class MyUpcomingSchedules(
+    val myUpcomingScheduleList: List<MyUpcomingScheduleInfo>,
+    val last: Boolean,
+)

--- a/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/repository/PlanRepository.kt
+++ b/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/repository/PlanRepository.kt
@@ -1,0 +1,12 @@
+package kr.tekit.lion.domain.repository
+
+import kr.tekit.lion.domain.model.schedule.MyElapsedSchedules
+import kr.tekit.lion.domain.model.schedule.MyUpcomingSchedules
+import kr.tekit.lion.domain.exception.Result
+
+interface PlanRepository {
+    suspend fun getMyUpcomingScheduleList(page: Int): Result<MyUpcomingSchedules>
+
+    suspend fun getMyElapsedScheduleList(page: Int): Result<MyElapsedSchedules>
+
+}

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myschedule/MyScheduleActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myschedule/MyScheduleActivity.kt
@@ -1,12 +1,62 @@
 package kr.tekit.lion.presentation.myschedule
 
 import android.os.Bundle
+import android.view.View
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import com.google.android.material.tabs.TabLayout
+import dagger.hilt.android.AndroidEntryPoint
+import kr.tekit.lion.presentation.myschedule.adapter.MyScheduleElapsedAdapter
+import kr.tekit.lion.presentation.myschedule.adapter.MyScheduleUpcomingAdapter
 import kr.tekit.lion.presentation.databinding.ActivityMyScheduleBinding
+import kr.tekit.lion.presentation.ext.addOnScrollEndListener
+import kr.tekit.lion.presentation.myschedule.vm.MyScheduleViewModel
 
+@AndroidEntryPoint
 class MyScheduleActivity : AppCompatActivity() {
+    private val viewModel: MyScheduleViewModel by viewModels()
+
     private val binding: ActivityMyScheduleBinding by lazy {
         ActivityMyScheduleBinding.inflate(layoutInflater)
+    }
+
+//    private val scheduleLauncher =
+//        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+//            viewModel.getMyUpcomingScheduleList(0)
+//            viewModel.getMyElapsedScheduleList(0)
+//            when (result.resultCode) {
+//                ResultCode.RESULT_REVIEW_WRITE -> {
+//                    binding.root.showSnackbar("후기가 저장되었습니다")
+//                }
+//            }
+//        }
+
+    private val upcomingAdapter by lazy {
+        MyScheduleUpcomingAdapter { planPosition ->
+            val planId = viewModel.getUpcomingPlanId(planPosition)
+            if (planId != -1L) {
+//                navigateToScheduleDetailActivity(planId)
+            }
+        }
+    }
+
+    private val elapsedAdapter by lazy {
+        MyScheduleElapsedAdapter(
+            onReviewButtonClicked = { planPosition ->
+                val planId = viewModel.getElapsedPlanId(planPosition)
+                if (planId != -1L) {
+//                    val intent = Intent(this, WriteScheduleReviewActivity::class.java)
+//                    intent.putExtra("planId", planId)
+//                    scheduleLauncher.launch(intent)
+                }
+            },
+            onScheduleItemClicked = { planPosition ->
+                val planId = viewModel.getElapsedPlanId(planPosition)
+                if (planId != -1L) {
+//                    navigateToScheduleDetailActivity(planId)
+                }
+            }
+        )
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -14,5 +64,93 @@ class MyScheduleActivity : AppCompatActivity() {
 
         setContentView(binding.root)
 
+        settingToolbar()
+        settingMyScheduleTab()
+        settingUpcomingScheduleAdapter()
+
     }
+
+    private fun settingToolbar() {
+        binding.toolbarMySchedule.setNavigationOnClickListener {
+            finish()
+        }
+    }
+
+    private fun settingMyScheduleTab() {
+        binding.tabLayoutMySchedule.addOnTabSelectedListener(object :
+            TabLayout.OnTabSelectedListener {
+            override fun onTabSelected(tab: TabLayout.Tab) {
+                when (tab.position) { // TO DO - List 없을 때 처리할 것
+                    0 -> settingUpcomingScheduleAdapter()
+                    1 -> settingElapsedScheduleAdapter()
+                }
+            }
+
+            override fun onTabUnselected(tab: TabLayout.Tab) {}
+
+            override fun onTabReselected(tab: TabLayout.Tab) {}
+        })
+    }
+
+    private fun settingUpcomingScheduleAdapter() {
+        binding.recyclerViewMyScheduleList.apply {
+            adapter = upcomingAdapter
+            addOnScrollEndListener {
+                with(viewModel) {
+                    if (!isUpcomingLastPage()) {
+                        fetchNextUpcomingSchedules()
+                    }
+                }
+            }
+        }
+
+        viewModel.upcomingSchedules.observe(this@MyScheduleActivity) {
+            if ((it?.size ?: 0) > 0) {
+
+                hideScheduleEmptyPrompt()
+                upcomingAdapter.submitList(it)
+            } else {
+                showScheduleEmptyPrompt()
+            }
+        }
+    }
+
+    private fun settingElapsedScheduleAdapter() {
+        binding.recyclerViewMyScheduleList.apply {
+            adapter = elapsedAdapter
+            addOnScrollEndListener {
+                with(viewModel) {
+                    if (!isElapsedLastPage()) {
+                        fetchNextElapsedSchedules()
+                    }
+                }
+            }
+        }
+
+        viewModel.elapsedSchedules.observe(this@MyScheduleActivity) {
+            if ((it?.size ?: 0) > 0) {
+                hideScheduleEmptyPrompt()
+                elapsedAdapter.submitList(it)
+            } else {
+                showScheduleEmptyPrompt()
+            }
+        }
+    }
+
+    private fun hideScheduleEmptyPrompt(){
+        binding.layoutMyScheduleEmpty.visibility = View.GONE
+        binding.recyclerViewMyScheduleList.visibility = View.VISIBLE
+    }
+
+    private fun showScheduleEmptyPrompt(){
+        binding.layoutMyScheduleEmpty.visibility = View.VISIBLE
+        binding.recyclerViewMyScheduleList.visibility = View.GONE
+    }
+
+//    private fun navigateToScheduleDetailActivity(planId: Long) {
+//        val intent = Intent(this, ScheduleDetailActivity::class.java)
+//        intent.putExtra("planId", planId)
+//        scheduleLauncher.launch(intent)
+//    }
+
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myschedule/MyScheduleActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myschedule/MyScheduleActivity.kt
@@ -2,10 +2,17 @@ package kr.tekit.lion.presentation.myschedule
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import kr.tekit.lion.presentation.databinding.ActivityMyScheduleBinding
 
 class MyScheduleActivity : AppCompatActivity() {
+    private val binding: ActivityMyScheduleBinding by lazy {
+        ActivityMyScheduleBinding.inflate(layoutInflater)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        setContentView(binding.root)
 
     }
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myschedule/adapter/MyScheduleElapsedAdapter.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myschedule/adapter/MyScheduleElapsedAdapter.kt
@@ -1,0 +1,95 @@
+package kr.tekit.lion.presentation.myschedule.adapter
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import kr.tekit.lion.domain.model.schedule.MyElapsedScheduleInfo
+import kr.tekit.lion.presentation.R
+import kr.tekit.lion.presentation.databinding.ItemMyScheduleElapsedBinding
+
+class MyScheduleElapsedAdapter(
+    private val onReviewButtonClicked: (planPosition: Int) -> Unit,
+    private val onScheduleItemClicked: (planPosition: Int) -> Unit
+) : ListAdapter<MyElapsedScheduleInfo, MyScheduleElapsedAdapter.ElapsedScheduleViewHolder>(diffUtil) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ElapsedScheduleViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        return ElapsedScheduleViewHolder(
+            ItemMyScheduleElapsedBinding.inflate(
+                inflater,
+                parent,
+                false
+            ), onReviewButtonClicked, onScheduleItemClicked
+        )
+    }
+
+    override fun onBindViewHolder(holder: ElapsedScheduleViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class ElapsedScheduleViewHolder(
+        private val binding: ItemMyScheduleElapsedBinding,
+        private val onReviewButtonClicked: (Int) -> Unit,
+        private val onScheduleItemClicked: (Int) -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        init {
+            binding.buttonMyScheduleElapsedReview.setOnClickListener {
+                onReviewButtonClicked(absoluteAdapterPosition)
+            }
+            binding.root.setOnClickListener {
+                onScheduleItemClicked(absoluteAdapterPosition)
+            }
+        }
+
+        fun bind(mySchedule: MyElapsedScheduleInfo) {
+            binding.apply {
+                buttonMyScheduleElapsedReview.apply {
+                    if (mySchedule.hasReview) {
+                        visibility = View.GONE
+                    } else {
+                        visibility = View.VISIBLE
+                    }
+                }
+
+                if (mySchedule.imageUrl != "") {
+                    Glide.with(itemView.context)
+                        .load(mySchedule.imageUrl)
+                        .placeholder(R.drawable.empty_view_small)
+                        .error(R.drawable.empty_view_small)
+                        .override(50, 50)
+                        .into(binding.imageViewMyScheduleElapsed)
+                }
+
+                textViewMyScheduleElapsedName.text = mySchedule.title
+                textViewMyScheduleElapsedPeriod.text = itemView.context.getString(
+                    R.string.text_schedule_period,
+                    mySchedule.startDate,
+                    mySchedule.endDate
+                )
+            }
+        }
+    }
+
+    companion object {
+        val diffUtil = object : DiffUtil.ItemCallback<MyElapsedScheduleInfo>() {
+            override fun areItemsTheSame(
+                oldItem: MyElapsedScheduleInfo,
+                newItem: MyElapsedScheduleInfo
+            ): Boolean {
+                return oldItem.planId == newItem.planId
+            }
+
+            override fun areContentsTheSame(
+                oldItem: MyElapsedScheduleInfo,
+                newItem: MyElapsedScheduleInfo
+            ): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+}

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myschedule/adapter/MyScheduleUpcomingAdapter.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myschedule/adapter/MyScheduleUpcomingAdapter.kt
@@ -1,0 +1,82 @@
+package kr.tekit.lion.presentation.myschedule.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import kr.tekit.lion.domain.model.schedule.MyUpcomingScheduleInfo
+import kr.tekit.lion.presentation.R
+import kr.tekit.lion.presentation.databinding.ItemMyScheduleUpcomingBinding
+
+class MyScheduleUpcomingAdapter(
+    private val onScheduleItemClicked: (layoutPosition: Int) -> Unit
+) : ListAdapter<MyUpcomingScheduleInfo, MyScheduleUpcomingAdapter.UpcomingScheduleViewHolder>(
+    diffUtil
+) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): UpcomingScheduleViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        return UpcomingScheduleViewHolder(
+            ItemMyScheduleUpcomingBinding.inflate(
+                inflater,
+                parent,
+                false
+            ), onScheduleItemClicked
+        )
+    }
+
+    override fun onBindViewHolder(holder: UpcomingScheduleViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    class UpcomingScheduleViewHolder(
+        private val binding: ItemMyScheduleUpcomingBinding,
+        private val onScheduleItemClicked: (Int) -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+        init {
+            binding.root.setOnClickListener {
+                onScheduleItemClicked(absoluteAdapterPosition)
+            }
+        }
+
+        fun bind(mySchedule: MyUpcomingScheduleInfo) {
+            binding.apply {
+                textViewMyScheduleUpcomingName.text = mySchedule.title
+                textViewMyScheduleUpcomingDDay.text = mySchedule.remainDate
+                textViewMyScheduleUpcomingPeriod.text = itemView.context.getString(
+                    R.string.text_schedule_period,
+                    mySchedule.startDate,
+                    mySchedule.endDate
+                )
+                if (mySchedule.imageUrl != "") {
+                    Glide.with(itemView.context)
+                        .load(mySchedule.imageUrl)
+                        .placeholder(R.drawable.empty_view_small)
+                        .error(R.drawable.empty_view_small)
+                        .override(50, 50)
+                        .into(binding.imageViewMyScheduleUpcoming)
+                }
+            }
+        }
+    }
+
+    companion object {
+        val diffUtil = object : DiffUtil.ItemCallback<MyUpcomingScheduleInfo>() {
+            override fun areItemsTheSame(
+                oldItem: MyUpcomingScheduleInfo,
+                newItem: MyUpcomingScheduleInfo
+            ): Boolean {
+                return oldItem.planId == newItem.planId
+            }
+
+            override fun areContentsTheSame(
+                oldItem: MyUpcomingScheduleInfo,
+                newItem: MyUpcomingScheduleInfo
+            ): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+}

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myschedule/vm/MyScheduleViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myschedule/vm/MyScheduleViewModel.kt
@@ -49,7 +49,7 @@ class MyScheduleViewModel @Inject constructor(
         _elapsedPageNo.value = pageNum
     }
 
-    private fun getMyUpcomingScheduleList(page: Int) {
+    fun getMyUpcomingScheduleList(page: Int) {
         setUpcomingPageNo(page)
         viewModelScope.launch {
             planRepository.getMyUpcomingScheduleList(page)
@@ -63,7 +63,7 @@ class MyScheduleViewModel @Inject constructor(
         }
     }
 
-    private fun getMyElapsedScheduleList(page: Int) {
+    fun getMyElapsedScheduleList(page: Int) {
         setElapsedPageNo(page)
         viewModelScope.launch {
             planRepository.getMyElapsedScheduleList(page)

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myschedule/vm/MyScheduleViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myschedule/vm/MyScheduleViewModel.kt
@@ -1,0 +1,130 @@
+package kr.tekit.lion.presentation.myschedule.vm
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import kr.tekit.lion.domain.exception.onError
+import kr.tekit.lion.domain.exception.onSuccess
+import kr.tekit.lion.domain.model.schedule.MyElapsedScheduleInfo
+import kr.tekit.lion.domain.model.schedule.MyUpcomingScheduleInfo
+import kr.tekit.lion.domain.repository.PlanRepository
+import kr.tekit.lion.presentation.delegate.NetworkErrorDelegate
+import javax.inject.Inject
+
+@HiltViewModel
+class MyScheduleViewModel @Inject constructor(
+    private val planRepository: PlanRepository
+) : ViewModel() {
+
+
+    @Inject
+    lateinit var networkErrorDelegate: NetworkErrorDelegate
+
+    private val _upcomingSchedules = MutableLiveData<List<MyUpcomingScheduleInfo>?>()
+    val upcomingSchedules: LiveData<List<MyUpcomingScheduleInfo>?> get() = _upcomingSchedules
+
+    private val _upcomingPageNo = MutableLiveData<Int>()
+    private val _isLastUpcoming = MutableLiveData<Boolean>()
+
+    private val _elapsedSchedules = MutableLiveData<List<MyElapsedScheduleInfo>?>()
+    val elapsedSchedules: LiveData<List<MyElapsedScheduleInfo>?> get() = _elapsedSchedules
+
+    private val _elapsedPageNo = MutableLiveData<Int>()
+    private val _isLastElapsed = MutableLiveData<Boolean>()
+
+    init {
+        getMyUpcomingScheduleList(0)
+        getMyElapsedScheduleList(0)
+    }
+
+    private fun setUpcomingPageNo(pageNum: Int) {
+        _upcomingPageNo.value = pageNum
+    }
+
+    private fun setElapsedPageNo(pageNum: Int) {
+        _elapsedPageNo.value = pageNum
+    }
+
+    private fun getMyUpcomingScheduleList(page: Int) {
+        setUpcomingPageNo(page)
+        viewModelScope.launch {
+            planRepository.getMyUpcomingScheduleList(page)
+                .onSuccess {
+                    _upcomingSchedules.value = it.myUpcomingScheduleList
+                    _isLastUpcoming.value = it.last
+                }.onError {
+                    networkErrorDelegate.handleNetworkError(it)
+                }
+        }
+    }
+
+    private fun getMyElapsedScheduleList(page: Int) {
+        setElapsedPageNo(page)
+        viewModelScope.launch {
+            planRepository.getMyElapsedScheduleList(page)
+                .onSuccess {
+                    _elapsedSchedules.value = it.myElapsedScheduleList
+                    _isLastElapsed.value = it.last
+                }.onError {
+                    networkErrorDelegate.handleNetworkError(it)
+                }
+        }
+    }
+
+    fun getUpcomingPlanId(planPosition: Int): Long {
+        return _upcomingSchedules.value?.get(planPosition)?.planId ?: -1
+    }
+
+    fun getElapsedPlanId(planPosition: Int): Long {
+        return _elapsedSchedules.value?.get(planPosition)?.planId ?: -1
+    }
+
+    fun isUpcomingLastPage(): Boolean {
+        return _isLastUpcoming.value ?: true
+    }
+
+    fun isElapsedLastPage(): Boolean {
+        return _isLastElapsed.value ?: true
+    }
+
+    fun fetchNextUpcomingSchedules() {
+        val page = _upcomingPageNo.value
+
+        if (page != null) {
+            setUpcomingPageNo(page + 1) // 페이지 번호 갱신
+
+            viewModelScope.launch {
+                planRepository.getMyUpcomingScheduleList(page + 1)
+                    .onSuccess {
+                        val newList = _upcomingSchedules.value.orEmpty() + it.myUpcomingScheduleList
+                        _upcomingSchedules.value = newList
+                        _isLastUpcoming.value = it.last
+                    }.onError {
+                        networkErrorDelegate.handleNetworkError(it)
+                    }
+            }
+        }
+    }
+
+    fun fetchNextElapsedSchedules() {
+        val page = _elapsedPageNo.value
+
+        if (page != null) {
+            setElapsedPageNo(page + 1)
+
+            viewModelScope.launch {
+                planRepository.getMyElapsedScheduleList(page + 1)
+                    .onSuccess {
+                        val newList = _elapsedSchedules.value.orEmpty() + it.myElapsedScheduleList
+                        _elapsedSchedules.value = newList
+                        _isLastElapsed.value = it.last
+                    }.onError {
+                        networkErrorDelegate.handleNetworkError(it)
+                    }
+            }
+        }
+    }
+}

--- a/DaOnGil/presentation/src/main/res/layout/activity_my_schedule.xml
+++ b/DaOnGil/presentation/src/main/res/layout/activity_my_schedule.xml
@@ -1,19 +1,89 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/main"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     tools:context=".myschedule.MyScheduleActivity">
 
-    <TextView
-        android:id="@+id/textView2"
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbarMySchedule"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/background_color"
+        android:minHeight="?attr/actionBarSize"
+        app:navigationIcon="@drawable/back_icon">
+
+        <TextView
+            style="@style/Theme.Toolbar.Title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/text_my_schedule" />
+
+    </com.google.android.material.appbar.MaterialToolbar>
+
+    <com.google.android.material.tabs.TabLayout
+        android:id="@+id/tabLayoutMySchedule"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="@string/text_my_schedule"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+        android:layout_marginStart="@dimen/margin_basic"
+        android:layout_marginTop="@dimen/margin_small1"
+        android:backgroundTint="@color/background_color"
+        app:tabGravity="start"
+        app:tabIndicatorFullWidth="true"
+        app:tabSelectedTextColor="@color/text_primary"
+        app:tabTextAppearance="@style/tabLayout_text_appearance"
+        app:tabTextColor="@color/text_tertiary">
+
+        <com.google.android.material.tabs.TabItem
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/text_schedule_upcoming" />
+
+        <com.google.android.material.tabs.TabItem
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/text_schedule_elapsed" />
+    </com.google.android.material.tabs.TabLayout>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerViewMyScheduleList"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clipToPadding="false"
+        android:paddingTop="@dimen/margin_big3"
+        android:paddingBottom="@dimen/margin_big2"
+        android:visibility="visible"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+
+    <LinearLayout
+        android:id="@+id/layoutMyScheduleEmpty"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_gravity="center"
+        android:layout_weight="1"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="@string/text_no_schedule"
+            android:textColor="@color/text_quaternary"
+            android:textSize="@dimen/font_big2" />
+
+        <TextView
+            android:id="@+id/textViewMyScheduleAdd"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:padding="@dimen/margin_small1"
+            android:text="@string/add_schedule"
+            android:textColor="@color/text_quaternary"
+            android:textSize="@dimen/font_small2" />
+    </LinearLayout>
+</LinearLayout>

--- a/DaOnGil/presentation/src/main/res/layout/item_my_schedule_elapsed.xml
+++ b/DaOnGil/presentation/src/main/res/layout/item_my_schedule_elapsed.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/cardViewMyScheduleElapsed"
+        style="@style/Widget.Material3.CardView.Filled"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/margin_basic"
+        android:layout_marginTop="@dimen/margin_small2"
+        android:layout_marginBottom="@dimen/margin_small1"
+        android:backgroundTint="@color/item_background"
+        app:cardCornerRadius="5dp"
+        app:cardElevation="4dp"
+        app:cardPreventCornerOverlap="true">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <View
+                android:id="@+id/viewMyScheduleElapsedDeco"
+                android:layout_width="5dp"
+                android:layout_height="0dp"
+                android:background="@color/days_elapsed"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/textViewMyScheduleElapsedName"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_big3"
+                android:layout_marginTop="@dimen/margin_big4"
+                android:layout_marginEnd="16dp"
+                android:ellipsize="end"
+                android:fontFamily="@font/pretendard_semibold"
+                android:maxLines="1"
+                android:textColor="@color/text_secondary"
+                android:textSize="@dimen/font_big2"
+                app:layout_constraintEnd_toStartOf="@+id/imageViewMyScheduleElapsed"
+                app:layout_constraintStart_toEndOf="@+id/viewMyScheduleElapsedDeco"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="경주여행" />
+
+            <TextView
+                android:id="@+id/textViewMyScheduleElapsedPeriod"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:layout_marginBottom="@dimen/margin_big4"
+                android:fontFamily="@font/pretendard_light"
+                android:textColor="@color/text_secondary"
+                app:layout_constraintBottom_toTopOf="@+id/buttonMyScheduleElapsedReview"
+                app:layout_constraintStart_toStartOf="@+id/textViewMyScheduleElapsedName"
+                app:layout_constraintTop_toBottomOf="@+id/textViewMyScheduleElapsedName"
+                tools:text="2024.04.01 - 04.05" />
+
+            <ImageView
+                android:id="@+id/imageViewMyScheduleElapsed"
+                android:layout_width="@dimen/search_bar_height"
+                android:layout_height="@dimen/search_bar_height"
+                android:layout_marginTop="@dimen/margin_small1"
+                android:layout_marginEnd="@dimen/margin_small1"
+                android:layout_marginBottom="@dimen/margin_small1"
+                android:contentDescription="@string/text_schedule_thumbnail_image"
+                android:scaleType="centerCrop"
+                app:layout_constraintBottom_toTopOf="@+id/buttonMyScheduleElapsedReview"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="@drawable/empty_view_small" />
+
+            <Button
+                android:id="@+id/buttonMyScheduleElapsedReview"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_big3"
+                android:layout_marginEnd="@dimen/margin_small1"
+                android:layout_marginBottom="@dimen/margin_small1"
+                android:background="@drawable/background_radius_5"
+                android:minHeight="0dp"
+                android:text="@string/text_write_schedule_review"
+                android:textColor="@color/text_quinary"
+                app:backgroundTint="@color/button_quaternary"
+                app:icon="@drawable/edit_icon"
+                app:iconGravity="textStart"
+                app:iconTint="@color/text_quinary"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/viewMyScheduleElapsedDeco" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+</LinearLayout>

--- a/DaOnGil/presentation/src/main/res/layout/item_my_schedule_upcoming.xml
+++ b/DaOnGil/presentation/src/main/res/layout/item_my_schedule_upcoming.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/cardViewRowSchedule"
+        style="@style/Widget.Material3.CardView.Filled"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/margin_basic"
+        android:layout_marginTop="@dimen/margin_small2"
+        android:layout_marginBottom="@dimen/margin_small1"
+        android:backgroundTint="@color/item_background"
+        app:cardCornerRadius="5dp"
+        app:cardElevation="4dp"
+        app:cardPreventCornerOverlap="true">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <View
+                android:id="@+id/viewMyScheduleUpcomingDeco"
+                android:layout_width="5dp"
+                android:layout_height="0dp"
+                android:background="@color/primary"
+                android:visibility="visible"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/textViewMyScheduleUpcomingName"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_big3"
+                android:layout_marginTop="@dimen/margin_big4"
+                android:ellipsize="end"
+                android:fontFamily="@font/pretendard_semibold"
+                android:maxLength="15"
+                android:maxLines="1"
+                android:textColor="@color/text_secondary"
+                android:textSize="@dimen/font_big2"
+                app:layout_constraintStart_toEndOf="@+id/viewMyScheduleUpcomingDeco"
+                app:layout_constraintTop_toTopOf="parent"
+                app:layout_constraintWidth_max="wrap"
+                tools:text="경주여행" />
+
+            <TextView
+                android:id="@+id/textViewMyScheduleUpcomingDDay"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_small1"
+                android:enabled="true"
+                android:fontFamily="@font/pretendard_semibold"
+                android:textColor="@color/color_schedule_d_day"
+                app:layout_constraintBottom_toBottomOf="@+id/textViewMyScheduleUpcomingName"
+                app:layout_constraintStart_toEndOf="@+id/textViewMyScheduleUpcomingName"
+                app:layout_constraintTop_toTopOf="@+id/textViewMyScheduleUpcomingName"
+                tools:text="D-1" />
+
+            <TextView
+                android:id="@+id/textViewMyScheduleUpcomingPeriod"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_big3"
+                android:layout_marginTop="@dimen/margin_small2"
+                android:layout_marginEnd="@dimen/margin_big3"
+                android:layout_marginBottom="@dimen/margin_big4"
+                android:fontFamily="@font/pretendard_light"
+                android:textColor="@color/text_secondary"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toStartOf="@+id/imageViewMyScheduleUpcoming"
+                app:layout_constraintStart_toEndOf="@+id/viewMyScheduleUpcomingDeco"
+                app:layout_constraintTop_toBottomOf="@+id/textViewMyScheduleUpcomingName"
+                tools:text="2024.04.01 - 04.05" />
+
+            <ImageView
+                android:id="@+id/imageViewMyScheduleUpcoming"
+                android:layout_width="@dimen/search_bar_height"
+                android:layout_height="@dimen/search_bar_height"
+                android:layout_marginEnd="@dimen/margin_small1"
+                android:contentDescription="@string/text_schedule_thumbnail_image"
+                android:scaleType="centerCrop"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="@drawable/empty_view_small" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+</LinearLayout>

--- a/DaOnGil/presentation/src/main/res/values/strings.xml
+++ b/DaOnGil/presentation/src/main/res/values/strings.xml
@@ -315,7 +315,7 @@
     <string name="text_reset_all_option">모든옵션이 초기화되었습니다.</string>
     <string name="text_select_all_option">모든옵션이 선택되었습니다.</string>
 
-
+    <string name="text_schedule_thumbnail_image">일정 대표사진</string>
     <string name="text_no_schedule">아직 등록된 일정이 없어요</string>
     <string name="text_explore_public_schedule">공개일정 둘러보기</string>
     <string name="text_add_new_schedule">새 여행 일정 추가하기</string>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #59 

## 📝작업 내용

-  내 일정 목록 UI 붙여넣기
- UI에 하드코딩 된 텍스트 제거
- 다가오는 일정 API 연결
- 다녀온 일정 API 연결
- 기존 코드 개선 (중복 코드 제거)

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
|다가오는 일정|다녀온 일정|
|:-----:|:-----:|
|![Screenshot_1725246840](https://github.com/user-attachments/assets/f51d2d3b-21c5-490a-81c2-07fd42c7018d)|![Screenshot_1725246843](https://github.com/user-attachments/assets/c2efd3a1-2a7c-42ff-9912-de3db32b332f)|

## 💬리뷰 요구사항(선택)

- 현재 다가오는 일정 API에서 다녀온 일정 API와 동일한 목록을 전달해주고 있어서, 임시로 남은 일정은 D-1 로 처리될 수 있도록 하드코딩 해뒀습니다. API 수정되면 이 부분도 확인하고 수정하겠습니다
- 예전에 UseCase에서 지정한 pageSize를 DataSource에서 지정해주었는데, 이런 식으로 처리해도 될까요?
- 첫 번째 페이지를 불러올 때, 항상 0 숫자를 직접 넣어줬었는데 이 부분을 private const val INITIAL_PAGE_NO = 0 이런 프로퍼티를 하나 만들어서 넣어줬습니다. ViewModel 위에 선언해주었는데 이런 식으로 해결하는 게 좋을까요? 아니면 그냥 0을 직접 쓰는 게 좋을까요?
- 데이터 받아오는 데 시간이 좀 걸려서, 여기에도 shimmer 라이브러리로 미리보기화면 넣으면 좋을 것 같더라구요. 이 부분은 API 연결 다 하고나서 해볼게요!
