### PR TITLE
[#71] 여행 일정 메인화면 내 일정 기능 구현

### DIFF
--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/datasource/PlanDataSource.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/datasource/PlanDataSource.kt
@@ -3,6 +3,7 @@ package kr.tekit.lion.data.datasource
 import kr.tekit.lion.data.common.execute
 import kr.tekit.lion.data.service.PlanService
 import kr.tekit.lion.domain.exception.Result
+import kr.tekit.lion.domain.model.MyMainSchedule
 import kr.tekit.lion.domain.model.schedule.MyElapsedSchedules
 import kr.tekit.lion.domain.model.schedule.MyUpcomingSchedules
 import javax.inject.Inject
@@ -20,5 +21,9 @@ internal class PlanDataSource @Inject constructor(
 
     suspend fun getMyElapsedScheduleList(page: Int): Result<MyElapsedSchedules> = execute {
         planService.getMyElapsedScheduleList(PAGE_SIZE, page).toDomainModel()
+    }
+
+    suspend fun getMyMainSchedule(): Result<List<MyMainSchedule?>?> = execute {
+        planService.getMyMainSchedule().toDomainModel()
     }
 }

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myMainSchedule/Data.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myMainSchedule/Data.kt
@@ -1,0 +1,14 @@
+package kr.tekit.lion.data.dto.response.plan.myMainSchedule
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+internal data class Data(
+    val endDate: String,
+    val hasReview: Boolean?,
+    val imageUrl: String?,
+    val planId: Long,
+    val remainDate: String?,
+    val startDate: String?,
+    val title: String?
+)

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myMainSchedule/MyMainScheduleResponse.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myMainSchedule/MyMainScheduleResponse.kt
@@ -1,0 +1,25 @@
+package kr.tekit.lion.data.dto.response.plan.myMainSchedule
+
+import com.squareup.moshi.JsonClass
+import kr.tekit.lion.domain.model.MyMainSchedule
+
+@JsonClass(generateAdapter = true)
+internal data class MyMainScheduleResponse(
+    val code: Int,
+    val data: List<Data?>?,
+    val message: String
+) {
+    fun toDomainModel(): List<MyMainSchedule?>? {
+        return data?.map{
+            MyMainSchedule(
+                endDate = it?.endDate,
+                hasReview = it?.hasReview,
+                imageUrl = it?.imageUrl,
+                planId = it?.planId,
+                remainDate = it?.remainDate,
+                startDate = it?.startDate,
+                title = it?.title
+            )
+        }
+    }
+}

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/repository/PlanRepositoryImpl.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/repository/PlanRepositoryImpl.kt
@@ -2,6 +2,7 @@ package kr.tekit.lion.data.repository
 
 import kr.tekit.lion.data.datasource.PlanDataSource
 import kr.tekit.lion.domain.exception.Result
+import kr.tekit.lion.domain.model.MyMainSchedule
 import kr.tekit.lion.domain.model.schedule.MyElapsedSchedules
 import kr.tekit.lion.domain.model.schedule.MyUpcomingSchedules
 import kr.tekit.lion.domain.repository.PlanRepository
@@ -16,5 +17,9 @@ internal class PlanRepositoryImpl @Inject constructor(
 
     override suspend fun getMyElapsedScheduleList(page: Int): Result<MyElapsedSchedules> {
         return planDataSource.getMyElapsedScheduleList(page)
+    }
+
+    override suspend fun getMyMainSchedule(): Result<List<MyMainSchedule?>?> {
+        return planDataSource.getMyMainSchedule()
     }
 }

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/service/PlanService.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/service/PlanService.kt
@@ -1,12 +1,13 @@
 package kr.tekit.lion.data.service
 
 
+import kr.tekit.lion.data.dto.response.plan.myMainSchedule.MyMainScheduleResponse
 import kr.tekit.lion.data.dto.response.plan.myScheduleElapsed.MyElapsedResponse
 import kr.tekit.lion.data.dto.response.plan.myScheduleUpcoming.MyUpcomingsResponse
 import retrofit2.http.GET
 import retrofit2.http.Query
 
-interface PlanService {
+internal interface PlanService {
     // 다가오는 일정 목록
     @GET("plan/my/not-complete")
     suspend fun getMyUpcomingScheduleList(
@@ -20,4 +21,8 @@ interface PlanService {
         @Query("size") size: Int,
         @Query("page") page: Int
     ): MyElapsedResponse
+
+    // 내 일정 정보
+    @GET("plan/my")
+    suspend fun getMyMainSchedule(): MyMainScheduleResponse
 }

--- a/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/model/MyMainSchedule.kt
+++ b/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/model/MyMainSchedule.kt
@@ -1,0 +1,11 @@
+package kr.tekit.lion.domain.model
+
+data class MyMainSchedule(
+    val endDate: String?,
+    val hasReview: Boolean?,
+    val imageUrl: String?,
+    val planId: Long?,
+    val remainDate: String?,
+    val startDate: String?,
+    val title: String?
+)

--- a/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/repository/PlanRepository.kt
+++ b/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/repository/PlanRepository.kt
@@ -3,10 +3,12 @@ package kr.tekit.lion.domain.repository
 import kr.tekit.lion.domain.model.schedule.MyElapsedSchedules
 import kr.tekit.lion.domain.model.schedule.MyUpcomingSchedules
 import kr.tekit.lion.domain.exception.Result
+import kr.tekit.lion.domain.model.MyMainSchedule
 
 interface PlanRepository {
     suspend fun getMyUpcomingScheduleList(page: Int): Result<MyUpcomingSchedules>
 
     suspend fun getMyElapsedScheduleList(page: Int): Result<MyElapsedSchedules>
 
+    suspend fun getMyMainSchedule(): Result<List<MyMainSchedule?>?>
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/adapter/ScheduleMyAdapter.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/adapter/ScheduleMyAdapter.kt
@@ -1,0 +1,90 @@
+package kr.tekit.lion.presentation.main.adapter
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import kr.tekit.lion.domain.model.MyMainSchedule
+import kr.tekit.lion.presentation.R
+import kr.tekit.lion.presentation.databinding.RowScheduleMyBinding
+import kr.tekit.lion.presentation.ext.setImage
+
+class ScheduleMyAdapter(
+    private val itemClickListener: (Int) -> Unit,
+    private val reviewClickListener: (Int) -> Unit
+) : RecyclerView.Adapter<ScheduleMyAdapter.ScheduleMyViewHolder>() {
+
+    private var items: MutableList<MyMainSchedule> = mutableListOf()
+
+    fun addItems(newItems: List<MyMainSchedule>){
+        items = newItems.toMutableList()
+        notifyDataSetChanged()
+    }
+
+    class ScheduleMyViewHolder(
+        private val binding: RowScheduleMyBinding,
+        private val itemClickListener: (Int) -> Unit,
+        private val reviewClickListener: (Int) -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        init {
+            binding.root.setOnClickListener {
+                itemClickListener(absoluteAdapterPosition)
+            }
+            binding.buttonRowScheduleReview.setOnClickListener {
+                reviewClickListener(absoluteAdapterPosition)
+            }
+        }
+
+        fun bind(item: MyMainSchedule) {
+
+            with(binding) {
+                textViewRowScheduleName.text = item.title
+                textViewRowSchedulePeriod.text = itemView.context.getString(
+                    R.string.text_schedule_period,
+                    item.startDate,
+                    item.endDate
+                )
+                root.context.setImage(imageViewRowSchedule, item.imageUrl)
+
+                // 다녀온 일정인 경우
+                if (item.remainDate == null) {
+                    viewRowScheduleRemainingDeco.visibility = View.INVISIBLE
+                    viewRowScheduleElapsedDeco.visibility = View.VISIBLE
+                    textViewRowScheduleDDay.visibility = View.INVISIBLE
+                    if(item.hasReview == false) {
+                        buttonRowScheduleReview.visibility = View.VISIBLE
+                    }
+                    if(item.hasReview == true){
+                        buttonRowScheduleReview.visibility = View.GONE
+                    }
+                }
+                // 다가오는 일정인 경우
+                else {
+                    viewRowScheduleRemainingDeco.visibility = View.VISIBLE
+                    viewRowScheduleElapsedDeco.visibility = View.INVISIBLE
+                    textViewRowScheduleDDay.isEnabled = true // 일정 상태에 따라 TextColor 변경
+                    textViewRowScheduleDDay.text = item.remainDate
+                    buttonRowScheduleReview.visibility = View.GONE // 후기작성 버튼 숨김처리
+                }
+            }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ScheduleMyViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        return ScheduleMyViewHolder(
+            RowScheduleMyBinding.inflate(inflater, parent, false),
+            itemClickListener,
+            reviewClickListener
+        )
+    }
+
+    override fun onBindViewHolder(holder: ScheduleMyViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
+
+    override fun getItemCount(): Int {
+        return items.size
+    }
+}

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/ScheduleMainFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/ScheduleMainFragment.kt
@@ -5,16 +5,20 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.LinearLayoutManager
 import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
+import kr.tekit.lion.domain.model.MyMainSchedule
 import kr.tekit.lion.presentation.R
 import kr.tekit.lion.presentation.scheduleform.ScheduleFormActivity
 import kr.tekit.lion.presentation.databinding.FragmentScheduleMainBinding
 import kr.tekit.lion.presentation.ext.repeatOnStarted
 import kr.tekit.lion.presentation.ext.showSnackbar
 import kr.tekit.lion.presentation.login.LoginActivity
+import kr.tekit.lion.presentation.main.adapter.ScheduleMyAdapter
 import kr.tekit.lion.presentation.main.dialog.ConfirmDialog
 import kr.tekit.lion.presentation.main.vm.schedule.ScheduleMainViewModel
 import kr.tekit.lion.presentation.myschedule.MyScheduleActivity
@@ -26,6 +30,14 @@ class ScheduleMainFragment : Fragment(R.layout.fragment_schedule_main) {
 
     private val viewModel: ScheduleMainViewModel by viewModels()
 
+    private val scheduleReviewLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+        /*if (result.resultCode == ResultCode.RESULT_REVIEW_WRITE) {
+            viewModel.getMyMainPlanList()
+            viewModel.getOpenPlanList()
+            view?.showSnackbar("후기가 저장되었습니다", Snackbar.LENGTH_LONG)
+        }*/
+    }
+
     private val scheduleFormLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()){ result ->
         if (result.resultCode == Activity.RESULT_OK) {
 //            viewModel.getMyMainPlanList()
@@ -34,12 +46,26 @@ class ScheduleMainFragment : Fragment(R.layout.fragment_schedule_main) {
         }
     }
 
+    private val scheduleDetailLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+        /*if (result.resultCode == Activity.RESULT_OK) {
+            view?.showSnackbar("일정이 삭제되었습니다", Snackbar.LENGTH_LONG)
+            viewModel.getMyMainPlanList()
+            viewModel.getOpenPlanList()
+        } else {
+            viewModel.getMyMainPlanList()
+            viewModel.getOpenPlanList()
+        }*/
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         val binding = FragmentScheduleMainBinding.bind(view)
 
+        settingRecyclerView(binding)
         initButtonClickListener(binding)
+
+        // viewModel.getOpenPlanList()
 
         repeatOnStarted {
             viewModel.loginState.collect { uiState ->
@@ -50,6 +76,7 @@ class ScheduleMainFragment : Fragment(R.layout.fragment_schedule_main) {
 
                     is LogInState.LoggedIn -> {
                         isUser = true
+                        viewModel.getMyMainPlanList()
                     }
 
                     is LogInState.LoginRequired -> {
@@ -59,6 +86,60 @@ class ScheduleMainFragment : Fragment(R.layout.fragment_schedule_main) {
                     }
                 }
             }
+        }
+    }
+
+    private fun settingRecyclerView(binding: FragmentScheduleMainBinding) {
+
+        with(binding) {
+            viewModel.myMainPlanList.observe(viewLifecycleOwner) {
+                if (it.isNullOrEmpty()) {
+                    showAddSchedulePrompt(binding)
+                    return@observe
+                }
+
+                binding.recyclerViewMySchedule.visibility = View.VISIBLE
+                binding.cardViewEmptySchedule.visibility = View.GONE
+
+                recyclerViewMySchedule.apply {
+                    val myscheduleAdapter = ScheduleMyAdapter(
+                        itemClickListener = { position ->
+                            // to do - 여행 일정 idx 전달
+                            val planId = it[position]?.planId
+                            planId?.let {
+                                initScheduleDetailActivity(it)
+                            }
+                        },
+                        reviewClickListener = { position ->
+                            /*val intent = Intent(requireActivity(), WriteScheduleReviewActivity::class.java)
+                            intent.putExtra("planId", it[position]?.planId)
+                            scheduleReviewLauncher.launch(intent)*/
+                        }
+                    )
+                    myscheduleAdapter.addItems(it as List<MyMainSchedule>)
+                    adapter = myscheduleAdapter
+
+                    layoutManager = LinearLayoutManager(requireContext(), LinearLayoutManager.VERTICAL, false)
+                }
+
+            }
+
+            // 공개 일정
+            /*recyclerViewPublicSchedule.apply {
+                viewModel.openPlanList.observe(viewLifecycleOwner) {
+                    val schedulePublicAdapter = SchedulePublicAdapter(
+                        itemClickListener = { position ->
+                            // to do - 여행 일정 idx 전달
+                            val planId = it[position]?.planId
+                            planId?.let {
+                                initScheduleDetailActivity(it)
+                            }
+                        }
+                    )
+                    schedulePublicAdapter.addItems(it)
+                    adapter = schedulePublicAdapter
+                }
+            }*/
         }
     }
 
@@ -109,4 +190,11 @@ class ScheduleMainFragment : Fragment(R.layout.fragment_schedule_main) {
         dialog.isCancelable = true
         dialog.show(activity?.supportFragmentManager!!, "ScheduleLoginDialog")
     }
+
+    private fun initScheduleDetailActivity(planId: Long){
+        /*val intent = Intent(requireActivity(), ScheduleDetailActivity::class.java)
+        intent.putExtra("planId", planId)
+        scheduleDetailLauncher.launch(intent)*/
+    }
+
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/vm/schedule/ScheduleMainViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/vm/schedule/ScheduleMainViewModel.kt
@@ -1,19 +1,33 @@
 package kr.tekit.lion.presentation.main.vm.schedule
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+import kr.tekit.lion.domain.exception.onError
+import kr.tekit.lion.domain.exception.onSuccess
+import kr.tekit.lion.domain.model.MyMainSchedule
 import kr.tekit.lion.domain.repository.AuthRepository
+import kr.tekit.lion.domain.repository.PlanRepository
+import kr.tekit.lion.presentation.delegate.NetworkErrorDelegate
 import kr.tekit.lion.presentation.splash.model.LogInState
 import javax.inject.Inject
 
 @HiltViewModel
 class ScheduleMainViewModel @Inject constructor(
     private val authRepository: AuthRepository,
+    private val planRepository: PlanRepository
 ) : ViewModel() {
+
+    @Inject
+    lateinit var networkErrorDelegate: NetworkErrorDelegate
+
+    private val _myMainPlanList = MutableLiveData<List<MyMainSchedule?>?>()
+    val myMainPlanList : LiveData<List<MyMainSchedule?>?> = _myMainPlanList
 
     private val _loginState = MutableStateFlow<LogInState>(LogInState.Checking)
     val loginState = _loginState.asStateFlow()
@@ -23,6 +37,15 @@ class ScheduleMainViewModel @Inject constructor(
             checkLoginState()
         }
     }
+
+    fun getMyMainPlanList() =
+        viewModelScope.launch {
+            planRepository.getMyMainSchedule().onSuccess {
+                _myMainPlanList.value = it
+            }.onError {
+                networkErrorDelegate.handleNetworkError(it)
+            }
+        }
 
     private fun checkLoginState() =
         viewModelScope.launch {

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/schedule/ResultCode.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/schedule/ResultCode.kt
@@ -1,0 +1,7 @@
+package kr.tekit.lion.presentation.schedule
+
+object ResultCode {
+    const val RESULT_REVIEW_WRITE = 1
+    const val RESULT_SCHEDULE_EDIT = 2
+    const val RESULT_REVIEW_EDIT = 3
+}

--- a/DaOnGil/presentation/src/main/res/layout/row_schedule_my.xml
+++ b/DaOnGil/presentation/src/main/res/layout/row_schedule_my.xml
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/cardViewRowSchedule"
+        style="@style/Widget.Material3.CardView.Filled"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/margin_basic"
+        android:layout_marginTop="@dimen/margin_small2"
+        android:layout_marginBottom="@dimen/margin_small1"
+        android:backgroundTint="@color/item_background"
+        app:cardCornerRadius="5dp"
+        app:cardElevation="4dp"
+        app:cardPreventCornerOverlap="true">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <View
+                android:id="@+id/viewRowScheduleRemainingDeco"
+                android:layout_width="5dp"
+                android:layout_height="0dp"
+                android:background="@color/primary"
+                android:visibility="visible"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <View
+                android:id="@+id/viewRowScheduleElapsedDeco"
+                android:layout_width="5dp"
+                android:layout_height="0dp"
+                android:background="@color/days_elapsed"
+                android:visibility="invisible"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
+
+            <TextView
+                android:id="@+id/textViewRowScheduleName"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_big3"
+                android:layout_marginTop="@dimen/margin_big4"
+                android:fontFamily="@font/pretendard_semibold"
+                android:textColor="@color/text_secondary"
+                android:textSize="@dimen/font_big2"
+                app:layout_constraintEnd_toStartOf="@+id/textViewRowScheduleDDay"
+                app:layout_constraintHorizontal_bias="0"
+                app:layout_constraintHorizontal_chainStyle="packed"
+                app:layout_constraintStart_toEndOf="@+id/viewRowScheduleRemainingDeco"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="경주여행" />
+
+            <TextView
+                android:id="@+id/textViewRowScheduleDDay"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_small1"
+                android:layout_marginEnd="@dimen/margin_small1"
+                android:enabled="true"
+                android:fontFamily="@font/pretendard_semibold"
+                android:textColor="@color/color_schedule_d_day"
+                app:layout_constraintBottom_toBottomOf="@+id/textViewRowScheduleName"
+                app:layout_constraintEnd_toStartOf="@+id/imageViewRowSchedule"
+                app:layout_constraintHorizontal_chainStyle="packed"
+                app:layout_constraintStart_toEndOf="@+id/textViewRowScheduleName"
+                app:layout_constraintTop_toTopOf="@+id/textViewRowScheduleName"
+                tools:text="D-1" />
+
+            <TextView
+                android:id="@+id/textViewRowSchedulePeriod"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:layout_marginBottom="@dimen/margin_big4"
+                android:fontFamily="@font/pretendard_light"
+                android:textColor="@color/text_secondary"
+                app:layout_constraintBottom_toTopOf="@+id/buttonRowScheduleReview"
+                app:layout_constraintStart_toStartOf="@+id/textViewRowScheduleName"
+                app:layout_constraintTop_toBottomOf="@+id/textViewRowScheduleName"
+                tools:text="2024.04.01 - 2024.04.05" />
+
+            <ImageView
+                android:id="@+id/imageViewRowSchedule"
+                android:layout_width="@dimen/search_bar_height"
+                android:layout_height="@dimen/search_bar_height"
+                android:layout_marginTop="@dimen/margin_small1"
+                android:layout_marginEnd="@dimen/margin_small1"
+                android:layout_marginBottom="@dimen/margin_small1"
+                android:contentDescription="대표 사진"
+                android:scaleType="centerCrop"
+                app:layout_constraintBottom_toTopOf="@+id/buttonRowScheduleReview"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="@drawable/empty_view_small" />
+
+            <Button
+                android:id="@+id/buttonRowScheduleReview"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_big3"
+                android:layout_marginEnd="@dimen/margin_small1"
+                android:layout_marginBottom="@dimen/margin_small1"
+                android:background="@drawable/background_radius_5"
+                android:minHeight="0dp"
+                android:text="@string/text_write_schedule_review"
+                android:textColor="@color/text_quinary"
+                android:visibility="gone"
+                app:backgroundTint="@color/button_quaternary"
+                app:icon="@drawable/edit_icon"
+                app:iconGravity="textStart"
+                app:iconTint="@color/text_quinary"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/viewRowScheduleRemainingDeco" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+</LinearLayout>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #71 

## 📝작업 내용

- 여행 일정 메인화면에서 내 일정 기능 구현했습니다!

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
<img src="https://github.com/user-attachments/assets/2f84ca72-3412-4419-bd8e-ccc1f80ea381" width="40%" height="40%"/>
<img src="https://github.com/user-attachments/assets/e8220590-925b-4303-857b-181421a16b9b" width="40%" height="40%"/>

## 💬리뷰 요구사항(선택)

- 다음 작업으로 밑에 공개일정 불러오는 거 진행하려고 합니다 ! 몇분 확인하시면 머지할게요 !!
