### PR TITLE
[#74] 여행 일정 메인화면 공개 일정 기능 구현

### DIFF
--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/datasource/PlanDataSource.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/datasource/PlanDataSource.kt
@@ -4,6 +4,7 @@ import kr.tekit.lion.data.common.execute
 import kr.tekit.lion.data.service.PlanService
 import kr.tekit.lion.domain.exception.Result
 import kr.tekit.lion.domain.model.MyMainSchedule
+import kr.tekit.lion.domain.model.OpenPlan
 import kr.tekit.lion.domain.model.schedule.MyElapsedSchedules
 import kr.tekit.lion.domain.model.schedule.MyUpcomingSchedules
 import javax.inject.Inject
@@ -25,5 +26,9 @@ internal class PlanDataSource @Inject constructor(
 
     suspend fun getMyMainSchedule(): Result<List<MyMainSchedule?>?> = execute {
         planService.getMyMainSchedule().toDomainModel()
+    }
+
+    suspend fun getOpenPlanList(size: Int, page: Int): Result<OpenPlan> = execute {
+        planService.getOpenPlanList(size, page).toDomainModel()
     }
 }

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/openSchedule/Data.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/openSchedule/Data.kt
@@ -1,0 +1,12 @@
+package kr.tekit.lion.data.dto.response.plan.openSchedule
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+internal data class Data(
+    val last: Boolean,
+    val openPlanResList: List<OpenPlanRes>,
+    val pageNo: Int,
+    val pageSize: Int,
+    val totalPages: Int
+)

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/openSchedule/OpenPlanListResponse.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/openSchedule/OpenPlanListResponse.kt
@@ -1,0 +1,31 @@
+package kr.tekit.lion.data.dto.response.plan.openSchedule
+
+import com.squareup.moshi.JsonClass
+import kr.tekit.lion.domain.model.OpenPlan
+import kr.tekit.lion.domain.model.OpenPlanInfo
+
+@JsonClass(generateAdapter = true)
+internal data class OpenPlanListResponse(
+    val code: Int,
+    val data: Data,
+    val message: String
+) {
+    fun toDomainModel() : OpenPlan {
+        return OpenPlan(
+            last = this.data.last,
+            pageNo = this.data.pageNo,
+            totalPages = this.data.totalPages,
+            openPlanList = this.data.openPlanResList.map {
+                OpenPlanInfo(
+                    date = it.date,
+                    imageUrl = it.imageUrl,
+                    memberId = it.memberId,
+                    memberImageUrl = it.memberImageUrl,
+                    memberNickname = it.memberNickname,
+                    planId = it.planId,
+                    title = it.title
+                )
+            }
+        )
+    }
+}

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/openSchedule/OpenPlanRes.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/openSchedule/OpenPlanRes.kt
@@ -1,0 +1,14 @@
+package kr.tekit.lion.data.dto.response.plan.openSchedule
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+internal data class OpenPlanRes(
+    val date: String,
+    val imageUrl: String?,
+    val memberId: Int,
+    val memberImageUrl: String,
+    val memberNickname: String,
+    val planId: Long,
+    val title: String
+)

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/repository/PlanRepositoryImpl.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/repository/PlanRepositoryImpl.kt
@@ -3,6 +3,7 @@ package kr.tekit.lion.data.repository
 import kr.tekit.lion.data.datasource.PlanDataSource
 import kr.tekit.lion.domain.exception.Result
 import kr.tekit.lion.domain.model.MyMainSchedule
+import kr.tekit.lion.domain.model.OpenPlan
 import kr.tekit.lion.domain.model.schedule.MyElapsedSchedules
 import kr.tekit.lion.domain.model.schedule.MyUpcomingSchedules
 import kr.tekit.lion.domain.repository.PlanRepository
@@ -21,5 +22,9 @@ internal class PlanRepositoryImpl @Inject constructor(
 
     override suspend fun getMyMainSchedule(): Result<List<MyMainSchedule?>?> {
         return planDataSource.getMyMainSchedule()
+    }
+
+    override suspend fun getOpenPlanList(size: Int, page: Int): Result<OpenPlan> {
+        return planDataSource.getOpenPlanList(size, page)
     }
 }

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/service/PlanService.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/service/PlanService.kt
@@ -4,8 +4,10 @@ package kr.tekit.lion.data.service
 import kr.tekit.lion.data.dto.response.plan.myMainSchedule.MyMainScheduleResponse
 import kr.tekit.lion.data.dto.response.plan.myScheduleElapsed.MyElapsedResponse
 import kr.tekit.lion.data.dto.response.plan.myScheduleUpcoming.MyUpcomingsResponse
+import kr.tekit.lion.data.dto.response.plan.openSchedule.OpenPlanListResponse
 import retrofit2.http.GET
 import retrofit2.http.Query
+import retrofit2.http.Tag
 
 internal interface PlanService {
     // 다가오는 일정 목록
@@ -25,4 +27,12 @@ internal interface PlanService {
     // 내 일정 정보
     @GET("plan/my")
     suspend fun getMyMainSchedule(): MyMainScheduleResponse
+
+    // 공개 일정 정보
+    @GET("plan/open")
+    suspend fun getOpenPlanList(
+        @Query("size") size: Int,
+        @Query("page") page: Int,
+        @Tag authType: AuthType = AuthType.NO_AUTH,
+    ): OpenPlanListResponse
 }

--- a/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/model/OpenPlan.kt
+++ b/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/model/OpenPlan.kt
@@ -1,0 +1,8 @@
+package kr.tekit.lion.domain.model
+
+data class OpenPlan(
+    val last: Boolean,
+    val openPlanList: List<OpenPlanInfo>,
+    val pageNo: Int,
+    val totalPages: Int
+)

--- a/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/model/OpenPlanInfo.kt
+++ b/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/model/OpenPlanInfo.kt
@@ -1,0 +1,11 @@
+package kr.tekit.lion.domain.model
+
+data class OpenPlanInfo (
+    val date: String,
+    val imageUrl: String?,
+    val memberId: Int,
+    val memberImageUrl: String,
+    val memberNickname: String,
+    val planId: Long,
+    val title: String
+)

--- a/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/repository/PlanRepository.kt
+++ b/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/repository/PlanRepository.kt
@@ -4,6 +4,7 @@ import kr.tekit.lion.domain.model.schedule.MyElapsedSchedules
 import kr.tekit.lion.domain.model.schedule.MyUpcomingSchedules
 import kr.tekit.lion.domain.exception.Result
 import kr.tekit.lion.domain.model.MyMainSchedule
+import kr.tekit.lion.domain.model.OpenPlan
 
 interface PlanRepository {
     suspend fun getMyUpcomingScheduleList(page: Int): Result<MyUpcomingSchedules>
@@ -11,4 +12,6 @@ interface PlanRepository {
     suspend fun getMyElapsedScheduleList(page: Int): Result<MyElapsedSchedules>
 
     suspend fun getMyMainSchedule(): Result<List<MyMainSchedule?>?>
+
+    suspend fun getOpenPlanList(size: Int, page: Int): Result<OpenPlan>
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/adapter/SchedulePublicAdapter.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/adapter/SchedulePublicAdapter.kt
@@ -1,0 +1,57 @@
+package kr.tekit.lion.presentation.main.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import kr.tekit.lion.domain.model.OpenPlanInfo
+import kr.tekit.lion.presentation.databinding.RowSchedulePublicBinding
+import kr.tekit.lion.presentation.ext.setImage
+
+class SchedulePublicAdapter(
+    private val itemClickListener: (Int) -> Unit
+) : RecyclerView.Adapter<SchedulePublicAdapter.SchedulePublicViewHolder>() {
+
+    private var items: MutableList<OpenPlanInfo> = mutableListOf()
+
+    fun addItems(newItems: List<OpenPlanInfo>) {
+        items = newItems.toMutableList()
+        notifyDataSetChanged()
+    }
+
+    class SchedulePublicViewHolder(
+        private val binding: RowSchedulePublicBinding, private val itemClickListener: (Int) -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+        init {
+            binding.root.setOnClickListener {
+                itemClickListener(adapterPosition)
+            }
+        }
+
+        fun bind(item: OpenPlanInfo) {
+            with(binding) {
+                textViewRowSchedulePublicPeriod.text = item.date
+                textViewRowScheduleName.text = item.title
+                textViewRowSchedulePublicNickname.text = item.memberNickname
+
+                root.context.setImage(imageViewRowSchedulePublicThumb, item.imageUrl)
+                root.context.setImage(imageViewRowSchedulePublicProfile, item.memberImageUrl)
+            }
+
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SchedulePublicViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        return SchedulePublicViewHolder(
+            RowSchedulePublicBinding.inflate(inflater, parent, false), itemClickListener
+        )
+    }
+
+    override fun onBindViewHolder(holder: SchedulePublicViewHolder, position: Int) {
+        holder.bind(items[position])
+    }
+
+    override fun getItemCount(): Int {
+        return items.size
+    }
+}

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/ScheduleMainFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/ScheduleMainFragment.kt
@@ -19,9 +19,11 @@ import kr.tekit.lion.presentation.ext.repeatOnStarted
 import kr.tekit.lion.presentation.ext.showSnackbar
 import kr.tekit.lion.presentation.login.LoginActivity
 import kr.tekit.lion.presentation.main.adapter.ScheduleMyAdapter
+import kr.tekit.lion.presentation.main.adapter.SchedulePublicAdapter
 import kr.tekit.lion.presentation.main.dialog.ConfirmDialog
 import kr.tekit.lion.presentation.main.vm.schedule.ScheduleMainViewModel
 import kr.tekit.lion.presentation.myschedule.MyScheduleActivity
+import kr.tekit.lion.presentation.schedule.ResultCode
 import kr.tekit.lion.presentation.splash.model.LogInState
 
 @AndroidEntryPoint
@@ -31,30 +33,30 @@ class ScheduleMainFragment : Fragment(R.layout.fragment_schedule_main) {
     private val viewModel: ScheduleMainViewModel by viewModels()
 
     private val scheduleReviewLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-        /*if (result.resultCode == ResultCode.RESULT_REVIEW_WRITE) {
+        if (result.resultCode == ResultCode.RESULT_REVIEW_WRITE) {
             viewModel.getMyMainPlanList()
             viewModel.getOpenPlanList()
             view?.showSnackbar("후기가 저장되었습니다", Snackbar.LENGTH_LONG)
-        }*/
+        }
     }
 
     private val scheduleFormLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()){ result ->
         if (result.resultCode == Activity.RESULT_OK) {
-//            viewModel.getMyMainPlanList()
-//            viewModel.getOpenPlanList()
+            viewModel.getMyMainPlanList()
+            viewModel.getOpenPlanList()
             view?.showSnackbar("일정이 저장되었습니다", Snackbar.LENGTH_LONG)
         }
     }
 
     private val scheduleDetailLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-        /*if (result.resultCode == Activity.RESULT_OK) {
+        if (result.resultCode == Activity.RESULT_OK) {
             view?.showSnackbar("일정이 삭제되었습니다", Snackbar.LENGTH_LONG)
             viewModel.getMyMainPlanList()
             viewModel.getOpenPlanList()
         } else {
             viewModel.getMyMainPlanList()
             viewModel.getOpenPlanList()
-        }*/
+        }
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -65,7 +67,7 @@ class ScheduleMainFragment : Fragment(R.layout.fragment_schedule_main) {
         settingRecyclerView(binding)
         initButtonClickListener(binding)
 
-        // viewModel.getOpenPlanList()
+        viewModel.getOpenPlanList()
 
         repeatOnStarted {
             viewModel.loginState.collect { uiState ->
@@ -125,7 +127,7 @@ class ScheduleMainFragment : Fragment(R.layout.fragment_schedule_main) {
             }
 
             // 공개 일정
-            /*recyclerViewPublicSchedule.apply {
+            recyclerViewPublicSchedule.apply {
                 viewModel.openPlanList.observe(viewLifecycleOwner) {
                     val schedulePublicAdapter = SchedulePublicAdapter(
                         itemClickListener = { position ->
@@ -139,7 +141,7 @@ class ScheduleMainFragment : Fragment(R.layout.fragment_schedule_main) {
                     schedulePublicAdapter.addItems(it)
                     adapter = schedulePublicAdapter
                 }
-            }*/
+            }
         }
     }
 

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/vm/schedule/ScheduleMainViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/vm/schedule/ScheduleMainViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.launch
 import kr.tekit.lion.domain.exception.onError
 import kr.tekit.lion.domain.exception.onSuccess
 import kr.tekit.lion.domain.model.MyMainSchedule
+import kr.tekit.lion.domain.model.OpenPlanInfo
 import kr.tekit.lion.domain.repository.AuthRepository
 import kr.tekit.lion.domain.repository.PlanRepository
 import kr.tekit.lion.presentation.delegate.NetworkErrorDelegate
@@ -29,6 +30,9 @@ class ScheduleMainViewModel @Inject constructor(
     private val _myMainPlanList = MutableLiveData<List<MyMainSchedule?>?>()
     val myMainPlanList : LiveData<List<MyMainSchedule?>?> = _myMainPlanList
 
+    private val _openPlanList = MutableLiveData<List<OpenPlanInfo>>()
+    val openPlanList : LiveData<List<OpenPlanInfo>> = _openPlanList
+
     private val _loginState = MutableStateFlow<LogInState>(LogInState.Checking)
     val loginState = _loginState.asStateFlow()
 
@@ -42,6 +46,15 @@ class ScheduleMainViewModel @Inject constructor(
         viewModelScope.launch {
             planRepository.getMyMainSchedule().onSuccess {
                 _myMainPlanList.value = it
+            }.onError {
+                networkErrorDelegate.handleNetworkError(it)
+            }
+        }
+
+    fun getOpenPlanList() =
+        viewModelScope.launch {
+            planRepository.getOpenPlanList(8, 0).onSuccess {
+                _openPlanList.value = it.openPlanList
             }.onError {
                 networkErrorDelegate.handleNetworkError(it)
             }

--- a/DaOnGil/presentation/src/main/res/layout/row_schedule_public.xml
+++ b/DaOnGil/presentation/src/main/res/layout/row_schedule_public.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/cardViewRowSchedulePublic"
+        style="@style/Widget.Material3.CardView.Filled"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="@dimen/margin_small1"
+        android:backgroundTint="@color/navi_background"
+        app:cardCornerRadius="5dp"
+        app:cardElevation="4dp"
+        app:cardPreventCornerOverlap="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <ImageView
+                android:id="@+id/imageViewRowSchedulePublicThumb"
+                android:layout_width="0dp"
+                android:layout_height="112dp"
+                android:contentDescription="대표 사진"
+                android:scaleType="centerCrop"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="@drawable/empty_view" />
+
+            <TextView
+                android:id="@+id/textViewRowSchedulePublicPeriod"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                android:layout_marginEnd="10dp"
+                android:background="@drawable/background_radius_50"
+                android:backgroundTint="@color/period_background"
+                android:fontFamily="@font/pretendard_semibold"
+                android:paddingHorizontal="10dp"
+                android:paddingVertical="@dimen/margin_small2"
+                android:textColor="@color/navi_background"
+                android:textSize="@dimen/font_small3"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                tools:text="3일일정" />
+
+            <TextView
+                android:id="@+id/textViewRowScheduleName"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_big4"
+                android:layout_marginTop="10dp"
+                android:layout_marginEnd="@dimen/margin_big4"
+                android:ellipsize="end"
+                android:maxLines="1"
+                android:textColor="@color/text_secondary"
+                android:textSize="@dimen/font_small1"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/imageViewRowSchedulePublicThumb"
+                tools:text="즐거운 경주 여행" />
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/cardViewRowSchedulePublicProfile"
+                android:layout_width="16dp"
+                android:layout_height="16dp"
+                android:layout_marginTop="@dimen/margin_small2"
+                android:layout_marginBottom="@dimen/margin_big4"
+                app:cardCornerRadius="@dimen/search_bar_height"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="@+id/textViewRowScheduleName"
+                app:layout_constraintTop_toBottomOf="@+id/textViewRowScheduleName">
+
+                <ImageView
+                    android:id="@+id/imageViewRowSchedulePublicProfile"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:contentDescription="프로필 사진"
+                    android:scaleType="centerCrop"
+                    android:src="@drawable/empty_view" />
+
+            </com.google.android.material.card.MaterialCardView>
+
+            <TextView
+                android:id="@+id/textViewRowSchedulePublicNickname"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_small2"
+                android:textColor="@color/text_secondary"
+                android:textSize="@dimen/font_small2"
+                app:layout_constraintBottom_toBottomOf="@+id/cardViewRowSchedulePublicProfile"
+                app:layout_constraintStart_toEndOf="@+id/cardViewRowSchedulePublicProfile"
+                app:layout_constraintTop_toTopOf="@+id/cardViewRowSchedulePublicProfile"
+                tools:text="김사자" />
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </com.google.android.material.card.MaterialCardView>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #74 

## 📝작업 내용

- 일정 메인화면에서 공개일정 모아보기 구현했습니다!

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
<img src="https://github.com/user-attachments/assets/83289d4e-2f46-4f98-a189-2be8561bece9" width="40%" height="40%"/>

## 💬리뷰 요구사항(선택)

- 아까 내일정이랑 크게 달라진 건 없어서 다음 작업 위해서 5시쯤 머지하겠습니다 !
