### PR TITLE
[#79] 여행일정 여행지 상세정보 api 연결

### DIFF
--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleElapsed/Data.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleElapsed/Data.kt
@@ -3,7 +3,7 @@ package kr.tekit.lion.data.dto.response.plan.myScheduleElapsed
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
-data class Data(
+internal data class Data(
     val planResList: List<PlanRes>,
     val pageNo: Int,
     val pageSize: Int,

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleElapsed/MyElapsedResponse.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleElapsed/MyElapsedResponse.kt
@@ -5,7 +5,7 @@ import kr.tekit.lion.domain.model.schedule.MyElapsedScheduleInfo
 import kr.tekit.lion.domain.model.schedule.MyElapsedSchedules
 
 @JsonClass(generateAdapter = true)
-data class MyElapsedResponse(
+internal data class MyElapsedResponse(
     val code: Int,
     val message: String,
     val data: Data,

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleElapsed/PlanRes.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleElapsed/PlanRes.kt
@@ -3,7 +3,7 @@ package kr.tekit.lion.data.dto.response.plan.myScheduleElapsed
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
-data class PlanRes(
+internal data class PlanRes(
     val planId: Long,
     val title: String,
     val startDate: String,

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleUpcoming/Data.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleUpcoming/Data.kt
@@ -3,7 +3,7 @@ package kr.tekit.lion.data.dto.response.plan.myScheduleUpcoming
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
-data class Data(
+internal data class Data(
     val planResList: List<PlanRes>,
     val pageNo: Int,
     val pageSize: Int,

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleUpcoming/MyUpcomingsResponse.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleUpcoming/MyUpcomingsResponse.kt
@@ -5,7 +5,7 @@ import kr.tekit.lion.domain.model.schedule.MyUpcomingScheduleInfo
 import kr.tekit.lion.domain.model.schedule.MyUpcomingSchedules
 
 @JsonClass(generateAdapter = true)
-data class MyUpcomingsResponse(
+internal data class MyUpcomingsResponse(
     val code: Int,
     val message: String,
     val data: Data,

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleUpcoming/PlanRes.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleUpcoming/PlanRes.kt
@@ -3,7 +3,7 @@ package kr.tekit.lion.data.dto.response.plan.myScheduleUpcoming
 import com.squareup.moshi.JsonClass
 
 @JsonClass(generateAdapter = true)
-data class PlanRes(
+internal data class PlanRes(
     val planId: Long,
     val title: String,
     val startDate: String,

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/FormSearchFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/FormSearchFragment.kt
@@ -29,7 +29,7 @@ class FormSearchFragment : Fragment(R.layout.fragment_form_search) {
     private val searchResultAdapter by lazy {
         FormSearchResultAdapter(
             onPlaceSelectedListener = { selectedPlacePosition ->
-                addNewPlace(args.schedulePosition, selectedPlacePosition, false)
+                addNewPlaceToList(args.schedulePosition, selectedPlacePosition, false)
             },
             onItemClickListener = { selectedPlacePosition ->
                 val placeId = viewModel.getPlaceId(selectedPlacePosition)
@@ -83,7 +83,7 @@ class FormSearchFragment : Fragment(R.layout.fragment_form_search) {
         }
     }
 
-    private fun addNewPlace(
+    private fun addNewPlaceToList(
         schedulePosition: Int,
         selectedPlacePosition: Int,
         isBookmarkedPlace: Boolean
@@ -96,12 +96,6 @@ class FormSearchFragment : Fragment(R.layout.fragment_form_search) {
         if (isDuplicate) {
             requireView().showSnackbar("이 여행지는 이미 일정에 추가되어 있습니다")
         } else {
-            // 중복되지 않은 여행지는 일정에 추가
-            viewModel.getSearchedPlaceDetailInfo(
-                schedulePosition,
-                selectedPlacePosition,
-                isBookmarkedPlace
-            )
             findNavController().popBackStack()
         }
     }
@@ -138,7 +132,7 @@ class FormSearchFragment : Fragment(R.layout.fragment_form_search) {
                 binding.recyclerViewFsBookmark.apply {
                     layoutManager = flexboxLayoutManager
                     adapter = FormBookmarkedPlacesAdapter(it) { selectedPlacePosition ->
-                        addNewPlace(schedulePosition, selectedPlacePosition, true)
+                        addNewPlaceToList(schedulePosition, selectedPlacePosition, true)
                     }
                 }
             } else {

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/FormSearchFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/FormSearchFragment.kt
@@ -1,5 +1,6 @@
 package kr.tekit.lion.presentation.scheduleform.fragment
 
+import android.content.Intent
 import android.os.Bundle
 import android.view.KeyEvent
 import androidx.fragment.app.Fragment
@@ -16,6 +17,7 @@ import kr.tekit.lion.presentation.R
 import kr.tekit.lion.presentation.databinding.FragmentFormSearchBinding
 import kr.tekit.lion.presentation.ext.addOnScrollEndListener
 import kr.tekit.lion.presentation.ext.showSnackbar
+import kr.tekit.lion.presentation.home.DetailActivity
 import kr.tekit.lion.presentation.scheduleform.adapter.FormBookmarkedPlacesAdapter
 import kr.tekit.lion.presentation.scheduleform.adapter.FormSearchResultAdapter
 import kr.tekit.lion.presentation.scheduleform.vm.ScheduleFormViewModel
@@ -32,8 +34,7 @@ class FormSearchFragment : Fragment(R.layout.fragment_form_search) {
             onItemClickListener = { selectedPlacePosition ->
                 val placeId = viewModel.getPlaceId(selectedPlacePosition)
                 if (placeId != -1L) {
-                    // TODO 주석 해제
-//                    showPlaceDetail(placeId)
+                    navigateToPlaceDetail(placeId)
                 }
             }
         )
@@ -95,7 +96,12 @@ class FormSearchFragment : Fragment(R.layout.fragment_form_search) {
         if (isDuplicate) {
             requireView().showSnackbar("이 여행지는 이미 일정에 추가되어 있습니다")
         } else {
-            // TODO 관광지 상세보기 API 연결해서 코드 수정
+            // 중복되지 않은 여행지는 일정에 추가
+            viewModel.getSearchedPlaceDetailInfo(
+                schedulePosition,
+                selectedPlacePosition,
+                isBookmarkedPlace
+            )
             findNavController().popBackStack()
         }
     }
@@ -143,5 +149,11 @@ class FormSearchFragment : Fragment(R.layout.fragment_form_search) {
                 }
             }
         }
+    }
+
+    private fun navigateToPlaceDetail(placeId: Long){
+        val intent = Intent(requireActivity(), DetailActivity::class.java)
+        intent.putExtra("detailPlaceId", placeId)
+        startActivity(intent)
     }
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/ScheduleConfirmFormFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/ScheduleConfirmFormFragment.kt
@@ -9,6 +9,7 @@ import kr.tekit.lion.domain.model.scheduleform.DailySchedule
 import kr.tekit.lion.presentation.R
 import kr.tekit.lion.presentation.databinding.FragmentScheduleConfirmFormBinding
 import kr.tekit.lion.presentation.ext.showSnackbar
+import kr.tekit.lion.presentation.schedule.ResultCode
 import kr.tekit.lion.presentation.scheduleform.adapter.FormConfirmScheduleAdapter
 import kr.tekit.lion.presentation.scheduleform.vm.ScheduleFormViewModel
 
@@ -58,8 +59,7 @@ class ScheduleConfirmFormFragment : Fragment(R.layout.fragment_schedule_confirm_
         binding.buttonScheduleFormSubmit.setOnClickListener { view ->
             viewModel.submitNewPlan{ _, requestFlag ->
                 if(requestFlag){
-                    // TODO 주석 해제
-//                    requireActivity().setResult(ResultCode.RESULT_SCHEDULE_EDIT)
+                    requireActivity().setResult(ResultCode.RESULT_SCHEDULE_EDIT)
                     requireActivity().finish()
                 }else{
                     view.showSnackbar("다시 시도해주세요")

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/ScheduleDetailsFormFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/ScheduleDetailsFormFragment.kt
@@ -1,5 +1,6 @@
 package kr.tekit.lion.presentation.scheduleform.fragment
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.View
@@ -9,6 +10,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kr.tekit.lion.domain.model.scheduleform.DailySchedule
 import kr.tekit.lion.presentation.R
 import kr.tekit.lion.presentation.databinding.FragmentScheduleDetailsFormBinding
+import kr.tekit.lion.presentation.home.DetailActivity
 import kr.tekit.lion.presentation.scheduleform.adapter.FormScheduleAdapter
 import kr.tekit.lion.presentation.scheduleform.vm.ScheduleFormViewModel
 
@@ -70,8 +72,7 @@ class ScheduleDetailsFormFragment : Fragment(R.layout.fragment_schedule_details_
             },
             onItemClickListener = { schedulePosition, placePosition ->
                 val placeId = dailyScheduleList[schedulePosition].dailyPlaces[placePosition].placeId
-                // TODO 주석 해제
-//                showPlaceDetail(placeId)
+                navigateToPlaceDetail(placeId)
             },
             onRemoveButtonClickListener = { schedulePosition, placePosition ->
                 // viewModel에서 해당 place 제거
@@ -86,10 +87,10 @@ class ScheduleDetailsFormFragment : Fragment(R.layout.fragment_schedule_details_
         navController.navigate(action)
     }
 
-//    private fun showPlaceDetail(placeId: Long){
-//        val intent = Intent(requireActivity(), DetailActivity::class.java)
-//        intent.putExtra("detailPlaceId", placeId)
-//        startActivity(intent)
-//    }
+    private fun navigateToPlaceDetail(placeId: Long) {
+        val intent = Intent(requireActivity(), DetailActivity::class.java)
+        intent.putExtra("detailPlaceId", placeId)
+        startActivity(intent)
+    }
 
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/vm/ScheduleFormViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/vm/ScheduleFormViewModel.kt
@@ -271,7 +271,31 @@ class ScheduleFormViewModel @Inject constructor(
                 return true
             }
         }
+
+        getPlaceInfoAndSave(dayPosition, selectedPlacePosition, isBookmarkedPlace)
+
         return false
+    }
+
+    private fun getPlaceInfoAndSave(
+        dayPosition: Int,
+        selectedPlacePosition: Int,
+        isBookmarkedPlace: Boolean
+    ) {
+        if (isBookmarkedPlace) {
+            getSearchedPlaceDetailInfo(dayPosition, selectedPlacePosition)
+        } else {
+            val placeInfo = _placeSearchResult.value?.placeInfoList?.get(selectedPlacePosition)
+            if (placeInfo != null) {
+                val formPlace = FormPlace(
+                    placeInfo.placeId,
+                    placeInfo.imageUrl,
+                    placeInfo.placeName,
+                    placeInfo.category
+                )
+                addNewPlace(formPlace, dayPosition)
+            }
+        }
     }
 
     private fun getBookmarkedPlaceList() {
@@ -286,14 +310,9 @@ class ScheduleFormViewModel @Inject constructor(
 
     fun getSearchedPlaceDetailInfo(
         dayPosition: Int,
-        selectedPlacePosition: Int,
-        isBookmarkedPlace: Boolean
+        selectedPlacePosition: Int
     ) {
-        val placeId = if (isBookmarkedPlace) {
-            _bookmarkedPlaces.value?.get(selectedPlacePosition)?.bookmarkedPlaceId
-        } else {
-            _placeSearchResult.value?.placeInfoList?.get(selectedPlacePosition)?.placeId
-        }
+        val placeId = _bookmarkedPlaces.value?.get(selectedPlacePosition)?.bookmarkedPlaceId
 
         viewModelScope.launch {
             placeId?.let {


### PR DESCRIPTION
## #️⃣연관된 이슈

- #79

## 📝작업 내용

- 여행지 상세보기 API 연결,
- 여행지 상세 화면 연결
- data 레이어 data class에 internal 접근제한자 추가 (내일정 목록 관련된 클래스)

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인



## 💬리뷰 요구사항(선택)

- 여행지 검색 API에서 전달해주는 여행지 정보(이름, 사진, 종류)와 
일정 목록에 여행지를 추가할 때 필요한 여행지 정보(이름, 사진, 종류)가 동일한데, 
이걸 다시 여행지 상세보기 API 로 호출하도록 다시 수정했는데, 이런 식으로 둬도 괜찮을까요 ? 