### PR TITLE
[#89] 관광지 후기 전체보기 구현

### DIFF
--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/datasource/PlaceDataSource.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/datasource/PlaceDataSource.kt
@@ -12,6 +12,7 @@ import kr.tekit.lion.domain.model.mainplace.PlaceMainInfo
 import kr.tekit.lion.domain.model.detailplace.PlaceDetailInfo
 import kr.tekit.lion.domain.model.detailplace.PlaceDetailInfoGuest
 import kr.tekit.lion.domain.model.placereview.WritePlaceReview
+import kr.tekit.lion.domain.model.placereviewlist.PlaceReviewInfo
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import okhttp3.ResponseBody
@@ -88,5 +89,9 @@ internal class PlaceDataSource @Inject constructor(
         images: List<MultipartBody.Part>
     ): Result<WritePlaceReview> = execute {
         placeService.writePlaceReviewData(placeId, placeReviewReq, images).toDomainModel()
+    }
+
+    suspend fun getPlaceReviewList(placeId: Long, size: Int, page: Int) : Result<PlaceReviewInfo> = execute {
+        placeService.getPlaceReviewList(placeId, size, page).toDomainModel()
     }
 }

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/placereviewlist/Data.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/placereviewlist/Data.kt
@@ -1,0 +1,16 @@
+package kr.tekit.lion.data.dto.response.placereviewlist
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+internal data class Data(
+    @Json(name = "myplaceReviewList")
+    val myPlaceReviewList: List<MyPlaceReview>,
+    val placeImg: String,
+    val pageNo: Int?,
+    val pageSize: Int?,
+    val placeAddress: String,
+    val placeName: String,
+    val totalPages: Int?
+)

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/placereviewlist/MyPlaceReview.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/placereviewlist/MyPlaceReview.kt
@@ -1,0 +1,16 @@
+package kr.tekit.lion.data.dto.response.placereviewlist
+
+import com.squareup.moshi.JsonClass
+import java.time.LocalDate
+
+@JsonClass(generateAdapter = true)
+internal data class MyPlaceReview(
+    val content: String,
+    val date: LocalDate,
+    val grade: Float,
+    val imageList: List<String>,
+    val nickname: String,
+    val profileImg: String,
+    val reviewId: Int,
+    val myReview: Boolean
+)

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/placereviewlist/PlaceReviewResponse.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/placereviewlist/PlaceReviewResponse.kt
@@ -1,0 +1,35 @@
+package kr.tekit.lion.data.dto.response.placereviewlist
+
+import com.squareup.moshi.JsonClass
+import kr.tekit.lion.domain.model.placereviewlist.PlaceReview
+import kr.tekit.lion.domain.model.placereviewlist.PlaceReviewInfo
+
+@JsonClass(generateAdapter = true)
+internal data class PlaceReviewResponse(
+    val code: Int,
+    val data: Data,
+    val message: String
+) {
+    fun toDomainModel(): PlaceReviewInfo {
+        return PlaceReviewInfo(
+            placeReviewList = data.myPlaceReviewList.map {
+                PlaceReview(
+                    content = it.content,
+                    date = it.date,
+                    grade = it.grade,
+                    imageList = it.imageList,
+                    nickname = it.nickname,
+                    profileImg = it.profileImg,
+                    reviewId = it.reviewId,
+                    myReview = it.myReview
+                )
+            },
+            placeImg = data.placeImg,
+            pageNo = data.pageNo,
+            pageSize = data.pageSize,
+            placeAddress = data.placeAddress,
+            placeName = data.placeName,
+            totalPages = data.totalPages
+        )
+    }
+}

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/repository/PlaceRepositoryImpl.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/repository/PlaceRepositoryImpl.kt
@@ -23,6 +23,7 @@ import kr.tekit.lion.domain.model.mainplace.PlaceMainInfo
 import kr.tekit.lion.domain.model.placereview.NewReviewData
 import kr.tekit.lion.domain.model.placereview.NewReviewImages
 import kr.tekit.lion.domain.model.placereview.WritePlaceReview
+import kr.tekit.lion.domain.model.placereviewlist.PlaceReviewInfo
 import kr.tekit.lion.domain.model.search.AutoCompleteKeyword
 
 internal class PlaceRepositoryImpl @Inject constructor(
@@ -89,5 +90,9 @@ internal class PlaceRepositoryImpl @Inject constructor(
             newReviewData.toRequestBody(),
             reviewImages.toMultiPartBody()
         )
+    }
+
+    override suspend fun getPlaceReviewList(placeId: Long, page: Int, size: Int): Result<PlaceReviewInfo> {
+        return placeDataSource.getPlaceReviewList(placeId, page, size)
     }
 }

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/service/PlaceService.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/service/PlaceService.kt
@@ -5,6 +5,7 @@ import kr.tekit.lion.data.dto.response.detailplace.DetailPlaceResponse
 import kr.tekit.lion.data.dto.response.detailplaceguest.DetailPlaceGuestResponse
 import kr.tekit.lion.data.dto.response.mainplace.MainPlaceResponse
 import kr.tekit.lion.data.dto.response.placereview.WritePlaceReviewResponse
+import kr.tekit.lion.data.dto.response.placereviewlist.PlaceReviewResponse
 import kr.tekit.lion.data.dto.response.searchplace.AutoCompleteKeywordResponse
 import kr.tekit.lion.data.dto.response.searchplace.list.SearchPlaceResponse
 import kr.tekit.lion.data.dto.response.searchplace.map.MapSearchResponse
@@ -99,4 +100,12 @@ internal interface PlaceService {
         @Part("placeReviewReq") placeReviewReq: RequestBody,
         @Part images : List<MultipartBody.Part>?
     ): WritePlaceReviewResponse
+
+    @GET("place/review/{placeId}")
+    suspend fun getPlaceReviewList(
+        @Path("placeId") placeId: Long,
+        @Query("size") size: Int,
+        @Query("page") page: Int,
+        @Tag authType: AuthType = AuthType.ACCESS_TOKEN
+    ): PlaceReviewResponse
 }

--- a/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/model/placereviewlist/PlaceReview.kt
+++ b/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/model/placereviewlist/PlaceReview.kt
@@ -1,0 +1,14 @@
+package kr.tekit.lion.domain.model.placereviewlist
+
+import java.time.LocalDate
+
+data class PlaceReview (
+    val content: String,
+    val date: LocalDate,
+    val grade: Float,
+    val imageList: List<String>,
+    val nickname: String,
+    val profileImg: String,
+    val reviewId: Int,
+    val myReview: Boolean
+)

--- a/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/model/placereviewlist/PlaceReviewInfo.kt
+++ b/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/model/placereviewlist/PlaceReviewInfo.kt
@@ -1,0 +1,11 @@
+package kr.tekit.lion.domain.model.placereviewlist
+
+data class PlaceReviewInfo (
+    val placeReviewList: List<PlaceReview>,
+    val placeImg: String,
+    val pageNo: Int?,
+    val pageSize: Int?,
+    val placeAddress: String,
+    val placeName: String,
+    val totalPages: Int?
+)

--- a/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/repository/PlaceRepository.kt
+++ b/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/repository/PlaceRepository.kt
@@ -15,6 +15,7 @@ import kr.tekit.lion.domain.model.mainplace.PlaceMainInfo
 import kr.tekit.lion.domain.model.placereview.NewReviewData
 import kr.tekit.lion.domain.model.placereview.NewReviewImages
 import kr.tekit.lion.domain.model.placereview.WritePlaceReview
+import kr.tekit.lion.domain.model.placereviewlist.PlaceReviewInfo
 import kr.tekit.lion.domain.model.search.AutoCompleteKeyword
 
 interface PlaceRepository {
@@ -45,4 +46,7 @@ interface PlaceRepository {
         newReviewData: NewReviewData,
         reviewImages: NewReviewImages
     ): Result<WritePlaceReview>
+
+    suspend fun getPlaceReviewList(placeId: Long, size: Int, page: Int): Result<PlaceReviewInfo>
+
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/ReviewListActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/ReviewListActivity.kt
@@ -2,20 +2,80 @@ package kr.tekit.lion.presentation.home
 
 import android.os.Bundle
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.bumptech.glide.Glide
+import dagger.hilt.android.AndroidEntryPoint
+import kr.tekit.lion.domain.model.placereviewlist.PlaceReview
 import kr.tekit.lion.presentation.R
+import kr.tekit.lion.presentation.databinding.ActivityReviewListBinding
+import kr.tekit.lion.presentation.ext.addOnScrollEndListener
+import kr.tekit.lion.presentation.home.adapter.ReviewListRVAdapter
+import kr.tekit.lion.presentation.home.vm.ReviewListViewModel
+import kr.tekit.lion.presentation.main.dialog.ConfirmDialog
 
+@AndroidEntryPoint
 class ReviewListActivity : AppCompatActivity() {
+    private val viewModel : ReviewListViewModel by viewModels()
+    private val binding : ActivityReviewListBinding by lazy {
+        ActivityReviewListBinding.inflate(layoutInflater)
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
-        setContentView(R.layout.activity_review_list)
-        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
-            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
-            insets
+        setContentView(binding.root)
+
+        val placeId = intent.getLongExtra("reviewPlaceId", -1)
+
+        settingToolbar()
+        getReviewListInfo(placeId)
+    }
+
+    private fun settingToolbar() {
+        binding.reviewListToolbar.setNavigationOnClickListener {
+            finish()
+        }
+    }
+
+    private fun settingReviewListRVAdapter(reviewList: List<PlaceReview>) {
+        val reviewListRVAdapter = ReviewListRVAdapter(reviewList) {
+            val dialog = ConfirmDialog(
+                "신고하기",
+                "해당 댓글을 신고하시겠습니까?",
+                "신고하기"
+            ) {
+                // 신고하기 api 연결
+            }
+            dialog.isCancelable = false
+            dialog.show(supportFragmentManager, "PlaceReviewListDialog")
+        }
+        binding.reviewListRv.adapter = reviewListRVAdapter
+        binding.reviewListRv.layoutManager = LinearLayoutManager(applicationContext)
+    }
+
+    private fun getReviewListInfo(placeId : Long) {
+        viewModel.getPlaceReview(placeId)
+
+        binding.reviewListRv.addOnScrollEndListener {
+            if (viewModel.isLastPage.value == false) {
+                viewModel.getNewPlaceReview(placeId)
+            }
+        }
+
+        viewModel.placeReviewInfo.observe(this@ReviewListActivity) { placeReviewInfo ->
+            binding.reviewListTitleTv.text = placeReviewInfo.placeName
+            binding.reviewListAddressTv.text = placeReviewInfo.placeAddress
+            binding.reviewListCount2Tv.text = placeReviewInfo.placeReviewList.size.toString()
+
+            Glide.with(binding.reviewListThumbnailIv)
+                .load(placeReviewInfo.placeImg)
+                .error(R.drawable.empty_view)
+                .into(binding.reviewListThumbnailIv)
+
+            settingReviewListRVAdapter(placeReviewInfo.placeReviewList)
         }
     }
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/adapter/ReviewListRVAdapter.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/adapter/ReviewListRVAdapter.kt
@@ -1,0 +1,70 @@
+package kr.tekit.lion.presentation.home.adapter
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import kr.tekit.lion.domain.model.placereviewlist.PlaceReview
+import kr.tekit.lion.presentation.R
+import kr.tekit.lion.presentation.databinding.ItemDetailReviewBigBinding
+
+class ReviewListRVAdapter(
+    private val reviewList: List<PlaceReview>,
+    private val dialogCallback: () -> Unit
+) : RecyclerView.Adapter<ReviewListRVAdapter.ReviewListViewHolder>() {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ReviewListViewHolder {
+        val binding: ItemDetailReviewBigBinding = ItemDetailReviewBigBinding.inflate(
+            LayoutInflater.from(parent.context), parent, false
+        )
+
+        return ReviewListViewHolder(binding, dialogCallback)
+    }
+
+    override fun getItemCount(): Int = reviewList.size
+
+    override fun onBindViewHolder(holder: ReviewListViewHolder, position: Int) {
+        holder.bind(reviewList[position])
+    }
+
+    class ReviewListViewHolder(
+        private val binding: ItemDetailReviewBigBinding,
+        private val dialogCallback: () -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(review: PlaceReview) {
+            binding.itemDetailReviewBigNickname.text = review.nickname
+            binding.itemDetailReviewBigContent.text = review.content
+            binding.itemDetailReviewBigDate.text = review.date.toString()
+            binding.itemDetailReviewBigRatingbar.rating = review.grade
+
+            Glide.with(binding.itemDetailReviewBigProfileIv.context)
+                .load(review.profileImg)
+                .error(R.drawable.default_profile)
+                .into(binding.itemDetailReviewBigProfileIv)
+
+            if (review.imageList != null) {
+                binding.itemDetailReviewBigRv.visibility = View.VISIBLE
+
+                val reviewImageRVAdapter = ReviewImageRVAdapter(review.imageList)
+                binding.itemDetailReviewBigRv.adapter = reviewImageRVAdapter
+                binding.itemDetailReviewBigRv.layoutManager =
+                    LinearLayoutManager(binding.root.context, LinearLayoutManager.HORIZONTAL, false)
+            } else {
+                binding.itemDetailReviewBigRv.visibility = View.GONE
+            }
+
+            binding.itemDetailReviewBigReportBtn.setOnClickListener {
+                dialogCallback()
+            }
+
+            if (review.myReview) {
+                binding.itemDetailReviewBigReportBtn.visibility = View.GONE
+            } else {
+                binding.itemDetailReviewBigReportBtn.visibility = View.VISIBLE
+            }
+
+        }
+    }
+}

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/vm/ReviewListViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/vm/ReviewListViewModel.kt
@@ -1,0 +1,62 @@
+package kr.tekit.lion.presentation.home.vm
+
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import kr.tekit.lion.domain.exception.onError
+import kr.tekit.lion.domain.exception.onSuccess
+import kr.tekit.lion.domain.model.placereviewlist.PlaceReviewInfo
+import kr.tekit.lion.domain.repository.PlaceRepository
+import javax.inject.Inject
+
+@HiltViewModel
+class ReviewListViewModel @Inject constructor(
+    private val getPlaceReviewListRepository: PlaceRepository
+) : ViewModel() {
+    private val _placeReviewInfo = MutableLiveData<PlaceReviewInfo>()
+    val placeReviewInfo : LiveData<PlaceReviewInfo> = _placeReviewInfo
+
+    private val _isLastPage = MutableLiveData<Boolean>()
+    val isLastPage : LiveData<Boolean> = _isLastPage
+
+    companion object {
+        const val PAGE_SIZE = 5
+    }
+
+    init {
+        _isLastPage.value = false
+    }
+
+    fun getPlaceReview(placeId: Long) = viewModelScope.launch {
+        getPlaceReviewListRepository.getPlaceReviewList(placeId, PAGE_SIZE, 0).onSuccess {
+            Log.d("getPlaceReview", it.toString())
+            _placeReviewInfo.value = it
+        }.onError {
+            Log.d("getPlaceReview", it.toString())
+        }
+    }
+
+    fun getNewPlaceReview(placeId: Long) = viewModelScope.launch {
+        val page = _placeReviewInfo.value?.pageNo
+
+        if (page != null) {
+            getPlaceReviewListRepository.getPlaceReviewList(placeId, size = PAGE_SIZE, page = page + 1).onSuccess {
+                if (it.pageNo == it.totalPages) {
+                    _isLastPage.value = true
+                } else {
+                    val reviews = _placeReviewInfo.value?.placeReviewList ?: emptyList()
+                    val newReviews = reviews + it.placeReviewList
+                    val newReviewData = it.copy(placeReviewList = newReviews)
+
+                    _placeReviewInfo.value = newReviewData
+                }
+            }.onError {
+                Log.d("getNewPlaceReview", it.toString())
+            }
+        }
+    }
+}

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/vm/ReviewListViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/vm/ReviewListViewModel.kt
@@ -11,12 +11,17 @@ import kr.tekit.lion.domain.exception.onError
 import kr.tekit.lion.domain.exception.onSuccess
 import kr.tekit.lion.domain.model.placereviewlist.PlaceReviewInfo
 import kr.tekit.lion.domain.repository.PlaceRepository
+import kr.tekit.lion.presentation.delegate.NetworkErrorDelegate
 import javax.inject.Inject
 
 @HiltViewModel
 class ReviewListViewModel @Inject constructor(
     private val getPlaceReviewListRepository: PlaceRepository
 ) : ViewModel() {
+
+    @Inject
+    lateinit var networkErrorDelegate: NetworkErrorDelegate
+
     private val _placeReviewInfo = MutableLiveData<PlaceReviewInfo>()
     val placeReviewInfo : LiveData<PlaceReviewInfo> = _placeReviewInfo
 
@@ -33,10 +38,9 @@ class ReviewListViewModel @Inject constructor(
 
     fun getPlaceReview(placeId: Long) = viewModelScope.launch {
         getPlaceReviewListRepository.getPlaceReviewList(placeId, PAGE_SIZE, 0).onSuccess {
-            Log.d("getPlaceReview", it.toString())
             _placeReviewInfo.value = it
         }.onError {
-            Log.d("getPlaceReview", it.toString())
+            networkErrorDelegate.handleNetworkError(it)
         }
     }
 
@@ -55,7 +59,7 @@ class ReviewListViewModel @Inject constructor(
                     _placeReviewInfo.value = newReviewData
                 }
             }.onError {
-                Log.d("getNewPlaceReview", it.toString())
+                networkErrorDelegate.handleNetworkError(it)
             }
         }
     }

--- a/DaOnGil/presentation/src/main/res/layout/activity_review_list.xml
+++ b/DaOnGil/presentation/src/main/res/layout/activity_review_list.xml
@@ -7,4 +7,156 @@
     android:layout_height="match_parent"
     tools:context=".home.ReviewListActivity">
 
+    <ScrollView
+        android:id="@+id/review_list_scroll"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:id="@+id/review_list_thumbnail_layout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <ImageView
+                    android:id="@+id/review_list_thumbnail_iv"
+                    android:layout_width="match_parent"
+                    android:layout_height="250dp"
+                    android:scaleType="centerCrop"
+                    android:src="@drawable/empty_view"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <View
+                    android:id="@+id/review_list_thumbnail_dark"
+                    android:layout_width="match_parent"
+                    android:layout_height="250dp"
+                    android:alpha="0.5"
+                    android:background="@color/black"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <TextView
+                    android:id="@+id/review_list_title_tv"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginBottom="@dimen/margin_small1"
+                    android:fontFamily="@font/pretendard_bold"
+                    android:text="관광지명"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/font_big1"
+                    app:layout_constraintBottom_toTopOf="@+id/review_list_address_tv"
+                    app:layout_constraintEnd_toEndOf="@+id/review_list_address_tv"
+                    app:layout_constraintStart_toStartOf="@+id/review_list_address_tv" />
+
+                <TextView
+                    android:id="@+id/review_list_address_tv"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginHorizontal="@dimen/margin_basic"
+                    android:layout_marginBottom="32dp"
+                    android:fontFamily="@font/pretendard_medium"
+                    android:text="주소"
+                    android:textColor="@color/white"
+                    android:textSize="@dimen/font_big3"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent" />
+
+                <com.google.android.material.appbar.MaterialToolbar
+                    android:id="@+id/review_list_toolbar"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@color/transparent"
+                    android:minHeight="?attr/actionBarSize"
+                    app:layout_collapseMode="pin"
+                    app:layout_collapseParallaxMultiplier="0.7"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent"
+                    app:navigationIcon="@drawable/back_icon"
+                    app:navigationIconTint="@color/white">
+
+                    <TextView
+                        android:id="@+id/review_list_toolbar_title_tv"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center"
+                        android:fontFamily="@font/pretendard_medium"
+                        android:text="관광지"
+                        android:textColor="@color/white"
+                        android:textSize="@dimen/font_big2" />
+
+                </com.google.android.material.appbar.MaterialToolbar>
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+            <TextView
+                android:id="@+id/review_list_count1_tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_basic"
+                android:layout_marginTop="@dimen/margin_basic"
+                android:fontFamily="@font/pretendard_semibold"
+                android:text="최근 리뷰 "
+                android:textColor="@color/text_primary"
+                android:textSize="@dimen/font_big1"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/review_list_thumbnail_layout" />
+
+            <TextView
+                android:id="@+id/review_list_count2_tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="@font/pretendard_semibold"
+                android:text="n"
+                android:textColor="@color/text_primary"
+                android:textSize="@dimen/font_big1"
+                app:layout_constraintStart_toEndOf="@+id/review_list_count1_tv"
+                app:layout_constraintTop_toTopOf="@+id/review_list_count1_tv" />
+
+            <TextView
+                android:id="@+id/review_list_count3_tv"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:fontFamily="@font/pretendard_semibold"
+                android:text="개"
+                android:textColor="@color/text_primary"
+                android:textSize="@dimen/font_big1"
+                app:layout_constraintStart_toEndOf="@+id/review_list_count2_tv"
+                app:layout_constraintTop_toTopOf="@+id/review_list_count1_tv" />
+
+            <com.google.android.material.divider.MaterialDivider
+                android:id="@+id/review_list_divider"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="10dp"
+                app:dividerColor="@color/detail_divider"
+                app:dividerThickness="1dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/review_list_count1_tv" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/review_list_rv"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_small2"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/review_list_divider" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #89 

## 📝작업 내용

- 관광지 후기 전체보기 구현

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
- 신고하기 버튼 유무
<img src="https://github.com/user-attachments/assets/cfb55de1-c92c-434e-94aa-76eb6261c9f4" width="40%" height="40%"/>

- 리뷰 사진 있는 ver
<img src="https://github.com/user-attachments/assets/ccd08fee-a5fe-43ab-83d9-8ce5675900cb" width="40%" height="40%"/>


## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  - 리뷰 조회 시 서버 s3? 문제로 지금 프로필 사진이 안나오는데 백엔드에 전달해 둔 상태입니다 !
  - 구현하다보니 저희 신고하기 api를 아무도 안맡은 것 같네요,,
