### PR TITLE
[#94] 홈 관광지 관련 화면 이동 연결

### DIFF
--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/DetailActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/DetailActivity.kt
@@ -29,7 +29,9 @@ import kr.tekit.lion.presentation.ext.repeatOnStarted
 import kr.tekit.lion.presentation.home.adapter.DetailDisabilityRVAdapter
 import kr.tekit.lion.presentation.home.adapter.DetailInfoRVAdapter
 import kr.tekit.lion.presentation.home.adapter.DetailReviewRVAdapter
+import kr.tekit.lion.presentation.home.model.toReviewInfo
 import kr.tekit.lion.presentation.home.vm.DetailViewModel
+import kr.tekit.lion.presentation.myreview.MyReviewActivity
 import kr.tekit.lion.presentation.splash.model.LogInState
 
 @AndroidEntryPoint
@@ -109,10 +111,18 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
             }
             startActivity(intent)
         }
+    }
+
+    private fun settingModifyBtn(review: Review) {
 
         binding.detailModifyReviewBtn.setOnClickListener {
+            val intent = Intent(this, MyReviewActivity::class.java)
+            val reviewInfo = review.toReviewInfo()
+            intent.putExtra("reviewInfo", reviewInfo)
 
+            startActivity(intent)
         }
+
     }
 
     private fun handleCommonDetailPlaceInfo(
@@ -130,8 +140,18 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
         category: String,
         subDisability: List<SubDisability>?
     ) {
-        reviewList?.let { settingReviewRVAdapter(it) }
+        reviewList?.let {
+            settingReviewRVAdapter(it)
+
+            val myReview = it.filter { review -> review.myReview }
+
+            myReview.forEach { review ->
+                settingModifyBtn(review)
+            }
+        }
+
         settingDisabilityRVAdapter(disability)
+
         if (subDisability != null) {
             settingDetailInfoRVAdapter(subDisability)
         }
@@ -169,7 +189,6 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
                     .into(detailThumbnailIv)
             }
         }
-
 
         val cameraUpdate = CameraUpdate.scrollTo(LatLng(longitude, latitude))
         naverMap.moveCamera(cameraUpdate)

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/model/HomeViewPagerPage.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/model/HomeViewPagerPage.kt
@@ -1,0 +1,18 @@
+package kr.tekit.lion.presentation.home.model
+
+sealed class HomeViewPagerPage {
+    data object SearchPlace: HomeViewPagerPage()
+    data object Emergency: HomeViewPagerPage()
+    data object Schedule: HomeViewPagerPage()
+
+    companion object {
+        fun fromPosition(position: Int): HomeViewPagerPage {
+            return when (position) {
+                0 -> SearchPlace
+                1 -> Emergency
+                2 -> Schedule
+                else -> throw IllegalArgumentException("Invalid position : $position")
+            }
+        }
+    }
+}

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/model/ReviewInfo.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/model/ReviewInfo.kt
@@ -1,0 +1,31 @@
+package kr.tekit.lion.presentation.home.model
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+import kr.tekit.lion.domain.model.detailplace.Review
+import java.time.LocalDate
+
+@Parcelize
+data class ReviewInfo (
+    val reviewId: Long,
+    val nickname : String,
+    val profileImg : String,
+    val content : String,
+    val reviewImgs : List<String>?,
+    val grade : Float,
+    val date : LocalDate,
+    val myReview : Boolean
+): Parcelable
+
+fun Review.toReviewInfo(): ReviewInfo {
+    return ReviewInfo(
+        reviewId = this.reviewId,
+        nickname = this.nickname,
+        profileImg = this.profileImg,
+        content = this.content,
+        reviewImgs = this.reviewImgs,
+        grade = this.grade,
+        date = this.date,
+        myReview = this.myReview
+    )
+}

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/adapter/HomeVPAdapter.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/adapter/HomeVPAdapter.kt
@@ -6,14 +6,17 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import kr.tekit.lion.presentation.databinding.ItemHomeVpBinding
 
-class HomeVPAdapter(private val images: List<Drawable>)
-    : RecyclerView.Adapter<HomeVPAdapter.ImageViewHolder>(){
+class HomeVPAdapter(
+    private val images: List<Drawable>,
+    private val onItemClickListener: (Int) -> Unit
+) : RecyclerView.Adapter<HomeVPAdapter.ImageViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ImageViewHolder {
-        val binding : ItemHomeVpBinding = ItemHomeVpBinding.inflate(
-            LayoutInflater.from(parent.context), parent, false)
+        val binding: ItemHomeVpBinding = ItemHomeVpBinding.inflate(
+            LayoutInflater.from(parent.context), parent, false
+        )
 
-        return ImageViewHolder(binding)
+        return ImageViewHolder(binding, onItemClickListener)
     }
 
     override fun getItemCount(): Int = images.size
@@ -22,11 +25,20 @@ class HomeVPAdapter(private val images: List<Drawable>)
         holder.bind(images[position], position + 1)
     }
 
-    class ImageViewHolder(private val binding: ItemHomeVpBinding)
-        : RecyclerView.ViewHolder(binding.root) {
+    class ImageViewHolder(
+        private val binding: ItemHomeVpBinding,
+        private val onItemClickListener: (Int) -> Unit
+    ) :
+        RecyclerView.ViewHolder(binding.root) {
         fun bind(image: Drawable, currentPage: Int) {
             binding.itemHomeIv.setImageDrawable(image)
             binding.itemHomeCountTv.text = currentPage.toString()
+
+            binding.root.setOnClickListener {
+                if (bindingAdapterPosition != RecyclerView.NO_POSITION) {
+                    onItemClickListener(bindingAdapterPosition)
+                }
+            }
         }
     }
 }

--- a/DaOnGil/presentation/src/main/res/navigation/bottom_navigation_graph.xml
+++ b/DaOnGil/presentation/src/main/res/navigation/bottom_navigation_graph.xml
@@ -8,7 +8,17 @@
         android:id="@+id/homeMainFragment"
         android:name="kr.tekit.lion.presentation.main.fragment.HomeMainFragment"
         android:label="fragment_home_main"
-        tools:layout="@layout/fragment_home_main" />
+        tools:layout="@layout/fragment_home_main" >
+        <action
+            android:id="@+id/action_homeMainFragment_to_searchPlaceMainFragment"
+            app:destination="@id/searchPlaceMainFragment" />
+        <action
+            android:id="@+id/action_homeMainFragment_to_emergencyMainFragment"
+            app:destination="@id/emergencyMainFragment" />
+        <action
+            android:id="@+id/action_homeMainFragment_to_scheduleMainFragment"
+            app:destination="@id/scheduleMainFragment" />
+    </fragment>
     <fragment
         android:id="@+id/searchPlaceMainFragment"
         android:name="kr.tekit.lion.presentation.main.fragment.SearchPlaceMainFragment"


### PR DESCRIPTION
## #️⃣연관된 이슈

- #94 

## 📝작업 내용

- 홈 뷰페이저 페이지 클릭 시 해당 화면으로 이동 (검색, 응급 지원, 일정 관리)
- 관광지 상세보기에서 리뷰 수정 버튼 클릭 시 수정 화면으로 이동

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
(동영상이 왜 링크로 첨부되는지 모르겠네요,, 🥹)
- 홈 뷰페이저 페이지 클릭 시 화면 이동
https://github.com/user-attachments/assets/c8d36486-05c8-43ae-8a94-8f819448183f

- 상세보기에서 리뷰 수정 화면으로 이동
https://github.com/user-attachments/assets/bdf76b4f-f33b-421a-b7d4-e93e8e915a0a

## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  - 홈 뷰페이저 페이지 이동 sealed class 만들어서 사용해봤는데 이렇게 사용하는 게 맞는지 확인 한번 부탁드립니다~
  - 리뷰 수정 화면으로 이동 시 해당 리뷰 화면으로 이동하는 건 정민언니 파트에서 마저 연결해줄 예정입니다 !
