### PR TITLE
[#102] 관광지 상세보기 UI 수정

### DIFF
--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/request/NewPlanRequest.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/request/NewPlanRequest.kt
@@ -3,7 +3,7 @@ package kr.tekit.lion.data.dto.request
 import com.squareup.moshi.Json
 
 import kr.tekit.lion.domain.model.scheduleform.NewPlan
-import kr.tekit.lion.data.dto.remote.request.util.AdapterProvider.Companion.JsonAdapter
+import kr.tekit.lion.data.dto.request.util.AdapterProvider.Companion.JsonAdapter
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody

--- a/DaOnGil/presentation/src/main/res/layout/activity_detail.xml
+++ b/DaOnGil/presentation/src/main/res/layout/activity_detail.xml
@@ -223,11 +223,11 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/margin_big4"
                 android:layout_marginEnd="@dimen/margin_basic"
+                android:layout_marginTop="1dp"
                 android:fontFamily="@font/pretendard_medium"
                 android:text="주소입니다"
                 android:textColor="@color/text_secondary"
                 android:textSize="@dimen/font_small1"
-                app:layout_constraintBottom_toBottomOf="@+id/detail_basic_address_tv"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@+id/detail_basic_address_tv"
                 app:layout_constraintTop_toTopOf="@+id/detail_basic_address_tv" />
@@ -236,10 +236,10 @@
                 android:id="@+id/detail_call_iv"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_big4"
                 android:src="@drawable/detail_call_icon"
                 app:layout_constraintStart_toStartOf="@+id/detail_address_iv"
-                app:layout_constraintTop_toBottomOf="@+id/detail_address_iv" />
+                app:layout_constraintTop_toTopOf="@+id/detail_call_tv"
+                app:layout_constraintBottom_toBottomOf="@+id/detail_call_tv"/>
 
             <TextView
                 android:id="@+id/detail_call_tv"
@@ -250,34 +250,31 @@
                 android:text="문의"
                 android:textColor="@color/text_primary"
                 android:textSize="@dimen/font_big3"
-                app:layout_constraintBottom_toBottomOf="@+id/detail_call_iv"
                 app:layout_constraintStart_toEndOf="@+id/detail_call_iv"
-                app:layout_constraintTop_toTopOf="@+id/detail_call_iv" />
+                app:layout_constraintTop_toTopOf="@+id/detail_call_content_tv" />
 
             <TextView
                 android:id="@+id/detail_call_content_tv"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/margin_big4"
-                android:layout_marginEnd="@dimen/margin_basic"
+                android:layout_marginTop="@dimen/margin_big4"
                 android:autoLink="phone"
                 android:fontFamily="@font/pretendard_medium"
                 android:text="010-1111-1111"
                 android:textColor="@color/text_secondary"
                 android:textSize="@dimen/font_small1"
-                app:layout_constraintBottom_toBottomOf="@+id/detail_call_tv"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@+id/detail_call_tv"
-                app:layout_constraintTop_toTopOf="@+id/detail_call_tv" />
+                app:layout_constraintEnd_toEndOf="@+id/detail_basic_address_content_tv"
+                app:layout_constraintStart_toStartOf="@+id/detail_basic_address_content_tv"
+                app:layout_constraintTop_toBottomOf="@+id/detail_basic_address_content_tv" />
 
             <ImageView
                 android:id="@+id/detail_link_iv"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_big4"
                 android:src="@drawable/detail_link_icon"
                 app:layout_constraintStart_toStartOf="@+id/detail_call_iv"
-                app:layout_constraintTop_toBottomOf="@+id/detail_call_iv" />
+                app:layout_constraintTop_toTopOf="@+id/detail_homepage_tv"
+                app:layout_constraintBottom_toBottomOf="@+id/detail_homepage_tv"/>
 
             <TextView
                 android:id="@+id/detail_homepage_tv"
@@ -288,25 +285,22 @@
                 android:text="링크"
                 android:textColor="@color/text_primary"
                 android:textSize="@dimen/font_big3"
-                app:layout_constraintBottom_toBottomOf="@+id/detail_link_iv"
                 app:layout_constraintStart_toEndOf="@+id/detail_link_iv"
-                app:layout_constraintTop_toTopOf="@+id/detail_link_iv" />
+                app:layout_constraintTop_toTopOf="@+id/detail_homepage_content_tv" />
 
             <TextView
                 android:id="@+id/detail_homepage_content_tv"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                android:layout_marginStart="@dimen/margin_big4"
-                android:layout_marginEnd="@dimen/margin_basic"
+                android:layout_marginTop="@dimen/margin_big4"
                 android:autoLink="web"
                 android:fontFamily="@font/pretendard_medium"
                 android:text="링크 url"
                 android:textColor="@color/text_secondary"
                 android:textSize="@dimen/font_small1"
-                app:layout_constraintBottom_toBottomOf="@+id/detail_homepage_tv"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toEndOf="@+id/detail_homepage_tv"
-                app:layout_constraintTop_toTopOf="@+id/detail_homepage_tv" />
+                app:layout_constraintEnd_toEndOf="@+id/detail_call_content_tv"
+                app:layout_constraintStart_toStartOf="@+id/detail_call_content_tv"
+                app:layout_constraintTop_toBottomOf="@+id/detail_call_content_tv"/>
 
             <TextView
                 android:id="@+id/detail_service_title_tv"


### PR DESCRIPTION
## #️⃣연관된 이슈

- #102 

## 📝작업 내용

- 관광지 상세보기 UI 수정 (기본 정보 라인들 top to top으로 수정)
- import 경로 에러 수정

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
- 상세보기 UI before
<img src="https://github.com/user-attachments/assets/22dec9f7-b44f-4f32-9336-f2edbc0472eb" width="40%" height="40%"/>

- 상세보기 UI after
<img src="https://github.com/user-attachments/assets/1f2667b6-3042-4342-9efb-f9a50d3139d4" width="40%" height="40%"/>


## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  - 보람님 파트에서 import 경로 에러나서 수정했는데 확인 한번 부탁드립니다 !
