### PR TITLE
[#98] 일정 후기 수정 기능 구현

### DIFF
--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/datasource/PlanDataSource.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/datasource/PlanDataSource.kt
@@ -63,6 +63,18 @@ internal class PlanDataSource @Inject constructor(
         }
     }
 
+    suspend fun modifyNewScheduleReview(
+        planId: Long,
+        scheduleReview: RequestBody,
+        images: List<MultipartBody.Part>?
+    ) = execute {
+        if(images.isNullOrEmpty()){
+            planService.modifyScheduleReviewTextOnly(planId, scheduleReview)
+        }else{
+            planService.modifyScheduleReview(planId, scheduleReview, images)
+        }
+    }
+
     suspend fun getDetailScheduleInfo(planId: Long): ScheduleDetailInfo {
         return planService.getDetailScheduleInfo(planId).toDomainModel()
     }
@@ -90,4 +102,6 @@ internal class PlanDataSource @Inject constructor(
     suspend fun deleteMyPlanSchedule(planId: Long): Result<Unit> = execute {
         planService.deleteMyPlanSchedule(planId)
     }
+
+
 }

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/request/ModifyScheduleReviewRequest.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/request/ModifyScheduleReviewRequest.kt
@@ -2,13 +2,9 @@ package kr.tekit.lion.data.dto.request
 
 import kr.tekit.lion.data.dto.request.util.AdapterProvider
 import kr.tekit.lion.domain.model.schedule.ModifiedScheduleReview
-import kr.tekit.lion.domain.model.schedule.ReviewImage
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
-import okhttp3.MultipartBody
 import okhttp3.RequestBody
-import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
-import java.io.File
 
 internal data class ModifyScheduleReviewRequest (
     val grade: Float?,
@@ -24,12 +20,4 @@ fun ModifiedScheduleReview.toRequestBody(): RequestBody {
             deleteImgUrls = this.deleteImgUrls
         )
     ).toRequestBody("application/json".toMediaTypeOrNull())
-}
-
-fun List<ReviewImage>.toMultiPartBodyList(): List<MultipartBody.Part> {
-    return this.map { image ->
-        val file = image.imagePath?.let { File(it) }
-        val requestBody = file?.asRequestBody("image/*".toMediaTypeOrNull())
-        MultipartBody.Part.createFormData("images", file?.name, requestBody!!)
-    }
 }

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/request/ModifyScheduleReviewRequest.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/request/ModifyScheduleReviewRequest.kt
@@ -2,9 +2,13 @@ package kr.tekit.lion.data.dto.request
 
 import kr.tekit.lion.data.dto.request.util.AdapterProvider
 import kr.tekit.lion.domain.model.schedule.ModifiedScheduleReview
+import kr.tekit.lion.domain.model.schedule.ReviewImage
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
 import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.asRequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.File
 
 internal data class ModifyScheduleReviewRequest (
     val grade: Float?,
@@ -21,3 +25,11 @@ fun ModifiedScheduleReview.toRequestBody(): RequestBody {
         )
     ).toRequestBody("application/json".toMediaTypeOrNull())
 }
+
+fun List<ReviewImage>.toMultipartBodyList(): List<MultipartBody.Part> {
+    return this.map { image ->
+        val file = image.imagePath?.let { File(it) }
+        val requestBody = file?.asRequestBody("image/*".toMediaTypeOrNull())
+        MultipartBody.Part.createFormData("images", file?.name, requestBody!!)
+    }
+    }

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/request/ModifyScheduleReviewRequest.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/request/ModifyScheduleReviewRequest.kt
@@ -1,0 +1,35 @@
+package kr.tekit.lion.data.dto.request
+
+import kr.tekit.lion.data.dto.request.util.AdapterProvider
+import kr.tekit.lion.domain.model.schedule.ModifiedScheduleReview
+import kr.tekit.lion.domain.model.schedule.ReviewImage
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.asRequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+import java.io.File
+
+internal data class ModifyScheduleReviewRequest (
+    val grade: Float?,
+    val content: String?,
+    val deleteImgUrls: List<String>?
+)
+
+fun ModifiedScheduleReview.toRequestBody(): RequestBody {
+    return AdapterProvider.JsonAdapter(ModifyScheduleReviewRequest::class.java).toJson(
+        ModifyScheduleReviewRequest(
+            grade = this.grade,
+            content = this.content,
+            deleteImgUrls = this.deleteImgUrls
+        )
+    ).toRequestBody("application/json".toMediaTypeOrNull())
+}
+
+fun List<ReviewImage>.toMultiPartBodyList(): List<MultipartBody.Part> {
+    return this.map { image ->
+        val file = image.imagePath?.let { File(it) }
+        val requestBody = file?.asRequestBody("image/*".toMediaTypeOrNull())
+        MultipartBody.Part.createFormData("images", file?.name, requestBody!!)
+    }
+}

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/repository/PlanRepositoryImpl.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/repository/PlanRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package kr.tekit.lion.data.repository
 
 import kr.tekit.lion.data.datasource.PlanDataSource
+import kr.tekit.lion.data.dto.request.toMultiPartBodyList
 import kr.tekit.lion.data.dto.request.toMultipartBodyList
 import kr.tekit.lion.data.dto.request.toRequestBody
 import kr.tekit.lion.domain.exception.Result
@@ -9,9 +10,11 @@ import kr.tekit.lion.domain.model.OpenPlan
 import kr.tekit.lion.domain.model.schedule.BriefScheduleInfo
 import kr.tekit.lion.domain.model.ScheduleDetailInfo
 import kr.tekit.lion.domain.model.ScheduleDetailReview
+import kr.tekit.lion.domain.model.schedule.ModifiedScheduleReview
 import kr.tekit.lion.domain.model.schedule.MyElapsedSchedules
 import kr.tekit.lion.domain.model.schedule.MyUpcomingSchedules
 import kr.tekit.lion.domain.model.schedule.NewScheduleReview
+import kr.tekit.lion.domain.model.schedule.ReviewImage
 import kr.tekit.lion.domain.model.schedule.ReviewImg
 import kr.tekit.lion.domain.model.scheduleform.NewPlan
 import kr.tekit.lion.domain.model.scheduleform.PlaceSearchResult
@@ -60,7 +63,19 @@ internal class PlanRepositoryImpl @Inject constructor(
             images.toMultipartBodyList()
         )
     }
-        
+
+    override suspend fun modifyScheduleReview(
+        reviewId: Long,
+        scheduleReview: ModifiedScheduleReview,
+        images: List<ReviewImage>?
+    ): Result<Unit> {
+        return planDataSource.modifyNewScheduleReview(
+            reviewId,
+            scheduleReview.toRequestBody(),
+            images?.toMultiPartBodyList()
+        )
+    }
+
     override suspend fun getDetailScheduleInfo(planId: Long): ScheduleDetailInfo {
         return planDataSource.getDetailScheduleInfo(planId)
     }

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/repository/PlanRepositoryImpl.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/repository/PlanRepositoryImpl.kt
@@ -13,6 +13,7 @@ import kr.tekit.lion.domain.model.schedule.ModifiedScheduleReview
 import kr.tekit.lion.domain.model.schedule.MyElapsedSchedules
 import kr.tekit.lion.domain.model.schedule.MyUpcomingSchedules
 import kr.tekit.lion.domain.model.schedule.NewScheduleReview
+import kr.tekit.lion.domain.model.schedule.ReviewImage
 import kr.tekit.lion.domain.model.schedule.ReviewImg
 import kr.tekit.lion.domain.model.scheduleform.NewPlan
 import kr.tekit.lion.domain.model.scheduleform.PlaceSearchResult
@@ -65,7 +66,7 @@ internal class PlanRepositoryImpl @Inject constructor(
     override suspend fun modifyScheduleReview(
         reviewId: Long,
         scheduleReview: ModifiedScheduleReview,
-        images: List<ReviewImg>?
+        images: List<ReviewImage>?
     ): Result<Unit> {
         return planDataSource.modifyNewScheduleReview(
             reviewId,

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/repository/PlanRepositoryImpl.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/repository/PlanRepositoryImpl.kt
@@ -1,7 +1,6 @@
 package kr.tekit.lion.data.repository
 
 import kr.tekit.lion.data.datasource.PlanDataSource
-import kr.tekit.lion.data.dto.request.toMultiPartBodyList
 import kr.tekit.lion.data.dto.request.toMultipartBodyList
 import kr.tekit.lion.data.dto.request.toRequestBody
 import kr.tekit.lion.domain.exception.Result
@@ -14,7 +13,6 @@ import kr.tekit.lion.domain.model.schedule.ModifiedScheduleReview
 import kr.tekit.lion.domain.model.schedule.MyElapsedSchedules
 import kr.tekit.lion.domain.model.schedule.MyUpcomingSchedules
 import kr.tekit.lion.domain.model.schedule.NewScheduleReview
-import kr.tekit.lion.domain.model.schedule.ReviewImage
 import kr.tekit.lion.domain.model.schedule.ReviewImg
 import kr.tekit.lion.domain.model.scheduleform.NewPlan
 import kr.tekit.lion.domain.model.scheduleform.PlaceSearchResult
@@ -67,12 +65,12 @@ internal class PlanRepositoryImpl @Inject constructor(
     override suspend fun modifyScheduleReview(
         reviewId: Long,
         scheduleReview: ModifiedScheduleReview,
-        images: List<ReviewImage>?
+        images: List<ReviewImg>?
     ): Result<Unit> {
         return planDataSource.modifyNewScheduleReview(
             reviewId,
             scheduleReview.toRequestBody(),
-            images?.toMultiPartBodyList()
+            images?.toMultipartBodyList()
         )
     }
 

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/service/PlanService.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/service/PlanService.kt
@@ -87,6 +87,23 @@ internal interface PlanService {
         @Path("planId") planId: Long,
         @Part("planReviewReq") scheduleReview: RequestBody,
     )
+
+    // 여행 일정 후기 수정
+    @Multipart
+    @PATCH("plan/review/{reviewId}")
+    suspend fun modifyScheduleReview(
+        @Path("reviewId") reviewId: Long,
+        @Part("planReviewReq") scheduleReview: RequestBody,
+        @Part images: List<MultipartBody.Part>
+    )
+
+    // 여행 일정 후기 수정 (이미지 제외)
+    @Multipart
+    @PATCH("plan/review/{reviewId}")
+    suspend fun modifyScheduleReviewTextOnly(
+        @Path("reviewId") reviewId: Long,
+        @Part("planReviewReq") scheduleReview: RequestBody
+    )
       
     // 여행 일정 상세보기 (로그인버전)
     @GET("plan/detail/{planId}")

--- a/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/model/schedule/ModifiedScheduleReview.kt
+++ b/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/model/schedule/ModifiedScheduleReview.kt
@@ -1,0 +1,7 @@
+package kr.tekit.lion.domain.model.schedule
+
+data class ModifiedScheduleReview(
+    val grade: Float?,
+    val content: String?,
+    val deleteImgUrls: List<String>?
+)

--- a/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/model/schedule/ReviewImage.kt
+++ b/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/model/schedule/ReviewImage.kt
@@ -1,0 +1,10 @@
+package kr.tekit.lion.domain.model.schedule
+
+import com.sun.jndi.toolkit.url.Uri
+
+data class ReviewImage(
+    val imageUrl: String? = null,
+    val imageUri: Uri,
+    // 갤러리에서 선택한 이미지의 file Path
+    val imagePath: String? = null
+)

--- a/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/model/schedule/ReviewImage.kt
+++ b/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/model/schedule/ReviewImage.kt
@@ -1,10 +1,10 @@
-package kr.tekit.lion.presentation.model
+package kr.tekit.lion.domain.model.schedule
 
-import android.net.Uri
+import java.net.URI
 
 data class ReviewImage(
     val imageUrl: String? = null,
-    val imageUri: Uri,
+    val imageUri: URI,
     // 갤러리에서 선택한 이미지의 file Path
     val imagePath: String? = null
 )

--- a/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/model/schedule/ScheduleReviewInfo.kt
+++ b/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/model/schedule/ScheduleReviewInfo.kt
@@ -1,0 +1,14 @@
+package kr.tekit.lion.domain.model.schedule
+
+data class ScheduleReviewInfo(
+    // 여행 일정 정보
+    val title: String,
+    val startDate: String,
+    val endDate: String,
+    val imageUrl: String,
+    // 리뷰 정보
+    val reviewId: Long,
+    val content: String,
+    val grade: Float,
+    val imageList: List<String>?,
+)

--- a/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/repository/PlanRepository.kt
+++ b/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/repository/PlanRepository.kt
@@ -12,6 +12,8 @@ import kr.tekit.lion.domain.model.schedule.NewScheduleReview
 import kr.tekit.lion.domain.model.schedule.ReviewImg
 import kr.tekit.lion.domain.model.ScheduleDetailInfo
 import kr.tekit.lion.domain.model.ScheduleDetailReview
+import kr.tekit.lion.domain.model.schedule.ModifiedScheduleReview
+import kr.tekit.lion.domain.model.schedule.ReviewImage
 
 interface PlanRepository {
     suspend fun getMyUpcomingScheduleList(page: Int): Result<MyUpcomingSchedules>
@@ -33,7 +35,13 @@ interface PlanRepository {
         scheduleReview: NewScheduleReview,
         images: List<ReviewImg>
     ): Result<Unit>
- 
+
+    suspend fun modifyScheduleReview(
+        reviewId: Long,
+        scheduleReview: ModifiedScheduleReview,
+        images: List<ReviewImage>?
+    ): Result<Unit>
+
     suspend fun getDetailScheduleInfo(planId: Long): ScheduleDetailInfo
 
     suspend fun getDetailScheduleInfoGuest(planId: Long): ScheduleDetailInfo

--- a/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/repository/PlanRepository.kt
+++ b/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/repository/PlanRepository.kt
@@ -13,7 +13,6 @@ import kr.tekit.lion.domain.model.schedule.ReviewImg
 import kr.tekit.lion.domain.model.ScheduleDetailInfo
 import kr.tekit.lion.domain.model.ScheduleDetailReview
 import kr.tekit.lion.domain.model.schedule.ModifiedScheduleReview
-import kr.tekit.lion.domain.model.schedule.ReviewImage
 
 interface PlanRepository {
     suspend fun getMyUpcomingScheduleList(page: Int): Result<MyUpcomingSchedules>
@@ -39,7 +38,7 @@ interface PlanRepository {
     suspend fun modifyScheduleReview(
         reviewId: Long,
         scheduleReview: ModifiedScheduleReview,
-        images: List<ReviewImage>?
+        images: List<ReviewImg>?
     ): Result<Unit>
 
     suspend fun getDetailScheduleInfo(planId: Long): ScheduleDetailInfo

--- a/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/repository/PlanRepository.kt
+++ b/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/repository/PlanRepository.kt
@@ -13,6 +13,7 @@ import kr.tekit.lion.domain.model.schedule.ReviewImg
 import kr.tekit.lion.domain.model.ScheduleDetailInfo
 import kr.tekit.lion.domain.model.ScheduleDetailReview
 import kr.tekit.lion.domain.model.schedule.ModifiedScheduleReview
+import kr.tekit.lion.domain.model.schedule.ReviewImage
 
 interface PlanRepository {
     suspend fun getMyUpcomingScheduleList(page: Int): Result<MyUpcomingSchedules>
@@ -38,7 +39,7 @@ interface PlanRepository {
     suspend fun modifyScheduleReview(
         reviewId: Long,
         scheduleReview: ModifiedScheduleReview,
-        images: List<ReviewImg>?
+        images: List<ReviewImage>?
     ): Result<Unit>
 
     suspend fun getDetailScheduleInfo(planId: Long): ScheduleDetailInfo

--- a/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/usecase/plan/GetScheduleReviewInfoUseCase.kt
+++ b/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/usecase/plan/GetScheduleReviewInfoUseCase.kt
@@ -1,0 +1,27 @@
+package kr.tekit.lion.domain.usecase.plan
+
+import kr.tekit.lion.domain.model.schedule.ScheduleReviewInfo
+import kr.tekit.lion.domain.repository.PlanRepository
+import kr.tekit.lion.domain.usecase.base.BaseUseCase
+import kr.tekit.lion.domain.usecase.base.Result
+import javax.inject.Inject
+
+class GetScheduleReviewInfoUseCase @Inject constructor(
+    private val planRepository: PlanRepository
+) : BaseUseCase() {
+    suspend operator fun invoke(planId: Long): Result<ScheduleReviewInfo> = execute {
+        val scheduleInfo = planRepository.getDetailScheduleInfo(planId)
+        val detailReview = planRepository.getDetailScheduleReview(planId)
+
+        ScheduleReviewInfo(
+            title = scheduleInfo.title,
+            startDate = scheduleInfo.startDate,
+            endDate = scheduleInfo.endDate,
+            imageUrl = scheduleInfo.images?.get(0) ?: "",
+            reviewId = detailReview.reviewId ?: -1,
+            content = detailReview.content ?: "",
+            grade = detailReview.grade?.toFloat() ?: 0.0F,
+            imageList = detailReview.imageList
+        )
+    }
+}

--- a/DaOnGil/presentation/src/main/AndroidManifest.xml
+++ b/DaOnGil/presentation/src/main/AndroidManifest.xml
@@ -8,6 +8,9 @@
 
     <application android:theme="@style/Base.Theme.DaOnGil">
         <activity
+            android:name=".schedulereview.ModifyScheduleReviewActivity"
+            android:exported="false" />
+        <activity
             android:name=".schedulereview.WriteScheduleReviewActivity"
             android:exported="false" />
         <activity
@@ -63,6 +66,7 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
@@ -71,8 +75,7 @@
             android:exported="false" />
         <activity
             android:name=".keyword.KeywordSearchActivity"
-            android:exported="false">
-        </activity>
+            android:exported="false"></activity>
     </application>
 
 </manifest>

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/model/ReviewImage.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/model/ReviewImage.kt
@@ -1,6 +1,6 @@
-package kr.tekit.lion.domain.model.schedule
+package kr.tekit.lion.presentation.model
 
-import com.sun.jndi.toolkit.url.Uri
+import android.net.Uri
 
 data class ReviewImage(
     val imageUrl: String? = null,

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myschedule/MyScheduleActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myschedule/MyScheduleActivity.kt
@@ -15,6 +15,7 @@ import kr.tekit.lion.presentation.ext.addOnScrollEndListener
 import kr.tekit.lion.presentation.ext.showSnackbar
 import kr.tekit.lion.presentation.myschedule.vm.MyScheduleViewModel
 import kr.tekit.lion.presentation.schedule.ResultCode
+import kr.tekit.lion.presentation.schedule.ScheduleDetailActivity
 import kr.tekit.lion.presentation.schedulereview.WriteScheduleReviewActivity
 
 @AndroidEntryPoint
@@ -40,7 +41,7 @@ class MyScheduleActivity : AppCompatActivity() {
         MyScheduleUpcomingAdapter { planPosition ->
             val planId = viewModel.getUpcomingPlanId(planPosition)
             if (planId != -1L) {
-//                navigateToScheduleDetailActivity(planId)
+                navigateToScheduleDetailActivity(planId)
             }
         }
     }
@@ -58,7 +59,7 @@ class MyScheduleActivity : AppCompatActivity() {
             onScheduleItemClicked = { planPosition ->
                 val planId = viewModel.getElapsedPlanId(planPosition)
                 if (planId != -1L) {
-//                    navigateToScheduleDetailActivity(planId)
+                    navigateToScheduleDetailActivity(planId)
                 }
             }
         )
@@ -152,10 +153,10 @@ class MyScheduleActivity : AppCompatActivity() {
         binding.recyclerViewMyScheduleList.visibility = View.GONE
     }
 
-//    private fun navigateToScheduleDetailActivity(planId: Long) {
-//        val intent = Intent(this, ScheduleDetailActivity::class.java)
-//        intent.putExtra("planId", planId)
-//        scheduleLauncher.launch(intent)
-//    }
+    private fun navigateToScheduleDetailActivity(planId: Long) {
+        val intent = Intent(this, ScheduleDetailActivity::class.java)
+        intent.putExtra("planId", planId)
+        scheduleLauncher.launch(intent)
+    }
 
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/schedule/ScheduleDetailActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/schedule/ScheduleDetailActivity.kt
@@ -32,6 +32,8 @@ import kr.tekit.lion.presentation.schedule.customview.ReviewReportDialog
 import kr.tekit.lion.presentation.schedule.customview.ScheduleManageBottomSheet
 import kr.tekit.lion.presentation.schedule.customview.ScheduleReviewManageBottomSheet
 import kr.tekit.lion.presentation.schedule.vm.ScheduleDetailViewModel
+import kr.tekit.lion.presentation.schedulereview.ModifyScheduleReviewActivity
+import kr.tekit.lion.presentation.schedulereview.WriteScheduleReviewActivity
 import kr.tekit.lion.presentation.splash.model.LogInState
 import java.util.Timer
 import kotlin.concurrent.scheduleAtFixedRate
@@ -177,14 +179,14 @@ class ScheduleDetailActivity : AppCompatActivity() {
                                 getString(R.string.text_leave_schedule_review)
 
                             cardViewScheduleEmptyReview.setOnClickListener {
-                                /*val newIntent =
+                                val newIntent =
                                     Intent(
                                         this@ScheduleDetailActivity,
                                         WriteScheduleReviewActivity::class.java
                                     )
                                 val planId = intent.getLongExtra("planId", -1)
                                 newIntent.putExtra("planId", planId)
-                                scheduleReviewLauncher.launch(newIntent)*/
+                                scheduleReviewLauncher.launch(newIntent)
                             }
                         } else {
                             cardViewScheduleEmptyReview.visibility = View.VISIBLE
@@ -418,10 +420,10 @@ class ScheduleDetailActivity : AppCompatActivity() {
                 binding.imageButtonScheduleManageReview.showSnackbar(getString(R.string.text_schedule_review_deleted))
             },
             onReviewEditClickListener = {
-                /*val newIntent =
+                val newIntent =
                     Intent(this@ScheduleDetailActivity, ModifyScheduleReviewActivity::class.java)
                 newIntent.putExtra("planId", planId)
-                scheduleReviewLauncher.launch(newIntent)*/
+                scheduleReviewLauncher.launch(newIntent)
             }).show(supportFragmentManager, "ScheduleReviewManageBottomSheet")
     }
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/schedulereview/ModifyScheduleReviewActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/schedulereview/ModifyScheduleReviewActivity.kt
@@ -15,7 +15,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
 import androidx.core.widget.addTextChangedListener
 import dagger.hilt.android.AndroidEntryPoint
-import kr.tekit.lion.presentation.model.ReviewImage
+import kr.tekit.lion.domain.model.schedule.ReviewImage
 import kr.tekit.lion.presentation.R
 import kr.tekit.lion.presentation.databinding.ActivityModifyScheduleReviewBinding
 import kr.tekit.lion.presentation.ext.setImage
@@ -25,6 +25,7 @@ import kr.tekit.lion.presentation.main.dialog.ConfirmDialog
 import kr.tekit.lion.presentation.schedule.ResultCode
 import kr.tekit.lion.presentation.schedulereview.adapter.ModifyReviewImageAdapter
 import kr.tekit.lion.presentation.schedulereview.vm.ModifyScheduleReviewViewModel
+import java.net.URI
 
 @AndroidEntryPoint
 class ModifyScheduleReviewActivity : AppCompatActivity() {
@@ -210,8 +211,13 @@ class ModifyScheduleReviewActivity : AppCompatActivity() {
     private fun saveImageDataAndPath(uri: Uri) {
         val imagePath = toAbsolutePath(uri)
         if (imagePath != null) {
-            val newImage = ReviewImage(imageUri = uri, imagePath = imagePath)
-            viewModel.addNewReviewImage(newImage)
+            try {
+                val newImage = ReviewImage(imageUri = URI(uri.toString()), imagePath = imagePath)
+                viewModel.addNewReviewImage(newImage)
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+
         }
     }
 

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/schedulereview/ModifyScheduleReviewActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/schedulereview/ModifyScheduleReviewActivity.kt
@@ -1,0 +1,19 @@
+package kr.tekit.lion.presentation.schedulereview
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import kr.tekit.lion.presentation.databinding.ActivityModifyScheduleReviewBinding
+
+class ModifyScheduleReviewActivity : AppCompatActivity() {
+
+    private val binding: ActivityModifyScheduleReviewBinding by lazy {
+        ActivityModifyScheduleReviewBinding.inflate(layoutInflater)
+    }
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContentView(binding.root)
+
+        val planId = intent.getLongExtra("planId", -1)
+    }
+}

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/schedulereview/ModifyScheduleReviewActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/schedulereview/ModifyScheduleReviewActivity.kt
@@ -1,10 +1,72 @@
 package kr.tekit.lion.presentation.schedulereview
 
+import android.app.Activity
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.net.Uri
+import android.os.Build
 import android.os.Bundle
+import android.os.ext.SdkExtensions
+import android.provider.Settings
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import androidx.core.widget.addTextChangedListener
+import dagger.hilt.android.AndroidEntryPoint
+import kr.tekit.lion.presentation.model.ReviewImage
+import kr.tekit.lion.presentation.R
 import kr.tekit.lion.presentation.databinding.ActivityModifyScheduleReviewBinding
+import kr.tekit.lion.presentation.ext.setImage
+import kr.tekit.lion.presentation.ext.showSnackbar
+import kr.tekit.lion.presentation.ext.toAbsolutePath
+import kr.tekit.lion.presentation.main.dialog.ConfirmDialog
+import kr.tekit.lion.presentation.schedule.ResultCode
+import kr.tekit.lion.presentation.schedulereview.adapter.ModifyReviewImageAdapter
+import kr.tekit.lion.presentation.schedulereview.vm.ModifyScheduleReviewViewModel
 
+@AndroidEntryPoint
 class ModifyScheduleReviewActivity : AppCompatActivity() {
+    private val viewModel: ModifyScheduleReviewViewModel by viewModels()
+
+    private val pickMedia =
+        registerForActivityResult(ActivityResultContracts.PickVisualMedia()) { uri ->
+            if (uri != null) {
+                saveImageDataAndPath(uri)
+            }
+        }
+
+    private val albumLauncher =
+        registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
+            // 사진 선택을 완료한 후 돌아왔다면
+            if (result.resultCode == Activity.RESULT_OK) {
+                // 선택한 이미지의 Uri 가져오기
+                val uri = result.data?.data
+                uri?.let {
+                    saveImageDataAndPath(uri)
+                }
+            }
+        }
+
+    private val permissionLauncher =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted ->
+            if (isGranted) {
+                startAlbumLauncher()
+            } else {
+                val permissionDialog = ConfirmDialog(
+                    "권한 설정", "갤러리 이용을 위해 권한 설정이 필요합니다", "권한 설정"
+                ){
+                    // 앱 설정 화면으로 이동
+                    val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                    val uri = Uri.fromParts("package", packageName, null)
+                    intent.data = uri
+                    startActivity(intent)
+                }
+                permissionDialog.isCancelable = false
+                permissionDialog.show(supportFragmentManager, "ScheduleReviewbnPermissionDialog")
+            }
+        }
 
     private val binding: ActivityModifyScheduleReviewBinding by lazy {
         ActivityModifyScheduleReviewBinding.inflate(layoutInflater)
@@ -15,5 +77,161 @@ class ModifyScheduleReviewActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         val planId = intent.getLongExtra("planId", -1)
+
+        initToolbar()
+        loadScheduleReview(planId)
+
+        initReviewContentWatcher()
+        settingImageRVAdapter()
+        settingButtonClickListner()
+    }
+
+    private fun initToolbar() {
+        binding.toolbarModifyScheduleReview.setNavigationOnClickListener {
+            setResult(RESULT_CANCELED)
+            finish()
+        }
+    }
+
+    private fun loadScheduleReview(planId: Long) {
+        viewModel.getScheduleReviewInfo(planId)
+
+        initView()
+    }
+
+    private fun initView() {
+        viewModel.originalReview.observe(this@ModifyScheduleReviewActivity) { scheduleReviewInfo ->
+            with(binding) {
+                textMsrScheduleTitle.text = scheduleReviewInfo.title
+                textMsrSchedulePeriod.text = getString(
+                    R.string.text_schedule_period,
+                    scheduleReviewInfo?.startDate,
+                    scheduleReviewInfo?.endDate
+                )
+                val isImageAvailable = scheduleReviewInfo.imageUrl.isNotEmpty()
+                if (isImageAvailable) {
+                    this@ModifyScheduleReviewActivity.setImage(
+                        imageMsrScheduleThumbnail,
+                        scheduleReviewInfo.imageUrl
+                    )
+                }
+
+                ratingbarMsr.rating = scheduleReviewInfo.grade
+                editMsrContent.setText(scheduleReviewInfo.content)
+            }
+        }
+
+        viewModel.numOfImages.observe(this@ModifyScheduleReviewActivity) { numOfImages ->
+            binding.textMsrPhotoNum.text =
+                getString(R.string.text_num_of_images, numOfImages)
+        }
+    }
+
+    private fun settingImageRVAdapter() {
+        viewModel.imageList.observe(this) { imageList ->
+            val modifyReviewImageAdapter = ModifyReviewImageAdapter(imageList) { position ->
+                viewModel.removeReviewImageFromList(position)
+            }
+            binding.recyclerViewMsrPhotos.adapter = modifyReviewImageAdapter
+        }
+    }
+
+    private fun settingButtonClickListner() {
+        binding.apply {
+            buttonMsrAddPhoto.setOnClickListener {
+                if (!viewModel.isMoreImageAttachable()) {
+                    it.showSnackbar("사진은 최대 4개까지 첨부할 수 있습니다")
+                    return@setOnClickListener
+                }
+
+                if (isPhotoPickerAvailable()) {
+                    pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
+                } else {
+                    checkPermission()
+                }
+            }
+
+            buttonMsrSubmit.setOnClickListener {
+                val isValid = isReviewValid()
+                if (!isValid) return@setOnClickListener
+
+                submitScheduleReviewUpdate()
+            }
+        }
+    }
+
+    private fun submitScheduleReviewUpdate() {
+        binding.apply {
+            val reviewContent = editMsrContent.text.toString()
+            val reviewGrade = ratingbarMsr.rating
+
+            viewModel.updateScheduleReview(reviewGrade, reviewContent) { _, requestFlag ->
+                if (requestFlag) {
+                    setResult(ResultCode.RESULT_SCHEDULE_EDIT)
+                    finish()
+                }
+            }
+        }
+    }
+
+    private fun isPhotoPickerAvailable(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            true
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            SdkExtensions.getExtensionVersion(Build.VERSION_CODES.R) >= 2
+        } else {
+            false
+        }
+    }
+
+    // 갤러리 접근 권한 확인 함수
+    private fun checkPermission() {
+        val permissionReadExternal = android.Manifest.permission.READ_EXTERNAL_STORAGE
+
+        val permissionReadExternalGranted = ContextCompat.checkSelfPermission(
+            this,
+            permissionReadExternal
+        ) == PackageManager.PERMISSION_GRANTED
+
+        // 포토피커를 사용하지 못하는 버전만 권한 확인 (SDK 30 미만)
+        if (permissionReadExternalGranted) {
+            startAlbumLauncher()
+        } else {
+            permissionLauncher.launch(android.Manifest.permission.READ_EXTERNAL_STORAGE)
+        }
+    }
+
+    private fun startAlbumLauncher() {
+        val albumIntent = Intent(Intent.ACTION_GET_CONTENT)
+        albumIntent.type = "image/*"  // 이미지 타입만 선택하도록 설정
+        albumLauncher.launch(albumIntent)
+    }
+
+    private fun saveImageDataAndPath(uri: Uri) {
+        val imagePath = toAbsolutePath(uri)
+        if (imagePath != null) {
+            val newImage = ReviewImage(imageUri = uri, imagePath = imagePath)
+            viewModel.addNewReviewImage(newImage)
+        }
+    }
+
+    private fun isReviewValid(): Boolean {
+        with(binding) {
+            val reviewContent = editMsrContent.text.toString()
+            if (reviewContent.isBlank()) {
+                textInputMsrContent.error =
+                    getString(R.string.text_warning_review_content_empty)
+                return false
+            }
+        }
+        return true
+    }
+
+    private fun initReviewContentWatcher() {
+        with(binding) {
+            editMsrContent.addTextChangedListener {
+                textInputMsrContent.error = null
+            }
+        }
     }
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/schedulereview/adapter/ModifyReviewImageAdapter.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/schedulereview/adapter/ModifyReviewImageAdapter.kt
@@ -6,7 +6,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import kr.tekit.lion.presentation.R
 import kr.tekit.lion.presentation.databinding.ItemReviewWriteImageBinding
-import kr.tekit.lion.presentation.model.ReviewImage
+import kr.tekit.lion.domain.model.schedule.ReviewImage
 
 class ModifyReviewImageAdapter (
     private val images : List<ReviewImage>,
@@ -41,8 +41,10 @@ class ModifyReviewImageAdapter (
         }
 
         fun bind(reviewImage: ReviewImage) {
+            val javaUriString = reviewImage.imageUri.toString()
+
             Glide.with(binding.itemWriteReviewImage.context)
-                .load(reviewImage.imageUri)
+                .load(javaUriString)
                 .error(R.drawable.empty_view_small)
                 .into(binding.itemWriteReviewImage)
         }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/schedulereview/adapter/ModifyReviewImageAdapter.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/schedulereview/adapter/ModifyReviewImageAdapter.kt
@@ -1,0 +1,50 @@
+package kr.tekit.lion.presentation.schedulereview.adapter
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.bumptech.glide.Glide
+import kr.tekit.lion.presentation.R
+import kr.tekit.lion.presentation.databinding.ItemReviewWriteImageBinding
+import kr.tekit.lion.presentation.model.ReviewImage
+
+class ModifyReviewImageAdapter (
+    private val images : List<ReviewImage>,
+    private val imageRemoveListener: (imagePosition: Int) -> Unit
+) : RecyclerView.Adapter<ModifyReviewImageAdapter.ModifyScheduleReviewImageViewHolder>(){
+
+    override fun onCreateViewHolder(
+        parent: ViewGroup,
+        viewType: Int
+    ): ModifyScheduleReviewImageViewHolder {
+        val binding: ItemReviewWriteImageBinding = ItemReviewWriteImageBinding.inflate(
+            LayoutInflater.from(parent.context), parent, false
+        )
+
+        return ModifyScheduleReviewImageViewHolder(binding, imageRemoveListener)
+    }
+
+    override fun onBindViewHolder(holder: ModifyScheduleReviewImageViewHolder, position: Int) {
+        holder.bind(images[position])
+    }
+
+    override fun getItemCount(): Int  = images.size
+
+    class ModifyScheduleReviewImageViewHolder(
+        private val binding: ItemReviewWriteImageBinding,
+        private val imageRemoveListener: (imagePosition: Int) -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+        init {
+            binding.itemWriteReviewCancelIb.setOnClickListener {
+                imageRemoveListener(absoluteAdapterPosition)
+            }
+        }
+
+        fun bind(reviewImage: ReviewImage) {
+            Glide.with(binding.itemWriteReviewImage.context)
+                .load(reviewImage.imageUri)
+                .error(R.drawable.empty_view_small)
+                .into(binding.itemWriteReviewImage)
+        }
+    }
+}

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/schedulereview/vm/ModifyScheduleReviewViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/schedulereview/vm/ModifyScheduleReviewViewModel.kt
@@ -1,6 +1,5 @@
 package kr.tekit.lion.presentation.schedulereview.vm
 
-import android.net.Uri
 import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -11,14 +10,14 @@ import kotlinx.coroutines.launch
 import kr.tekit.lion.domain.exception.onError
 import kr.tekit.lion.domain.exception.onSuccess
 import kr.tekit.lion.domain.model.schedule.ModifiedScheduleReview
-import kr.tekit.lion.domain.model.schedule.ReviewImg
-import kr.tekit.lion.presentation.model.ReviewImage
+import kr.tekit.lion.domain.model.schedule.ReviewImage
 import kr.tekit.lion.domain.model.schedule.ScheduleReviewInfo
 import kr.tekit.lion.domain.repository.PlanRepository
 import kr.tekit.lion.domain.usecase.base.onError
 import kr.tekit.lion.domain.usecase.base.onSuccess
 import kr.tekit.lion.domain.usecase.plan.GetScheduleReviewInfoUseCase
 import kr.tekit.lion.presentation.delegate.NetworkErrorDelegate
+import java.net.URI
 import javax.inject.Inject
 
 @HiltViewModel
@@ -93,7 +92,7 @@ data class ModifyScheduleReviewViewModel @Inject constructor(
             val reviewImages = it.map { imageUrl ->
                 ReviewImage(
                     imageUrl = imageUrl,
-                    imageUri = Uri.parse(imageUrl),
+                    imageUri = URI(imageUrl),
                     imagePath = null
                 )
             }
@@ -148,19 +147,15 @@ data class ModifyScheduleReviewViewModel @Inject constructor(
         } ?: true
     }
 
-    private fun getNewImages() : List<ReviewImg> {
+    private fun getNewImages() : List<ReviewImage> {
         val originalImageSize = _originalReview.value?.imageList?.size ?: 0
         val deletedImageSize = _deleteImgUrls.value?.size ?: 0
         val currentImageSize = _imageList.value?.size ?: 0
 
         val startPoint = originalImageSize - deletedImageSize
 
-        val newImages = _imageList.value?.subList(startPoint, currentImageSize)
+        val newImages = _imageList.value?.subList(startPoint, currentImageSize) ?: emptyList()
 
-        val newImagePaths = newImages?.mapNotNull { reviewImage ->
-            reviewImage.imagePath?.let { imagePath -> ReviewImg(path = imagePath) }
-        } ?: emptyList()
-
-        return newImagePaths
+        return newImages
     }
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/schedulereview/vm/ModifyScheduleReviewViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/schedulereview/vm/ModifyScheduleReviewViewModel.kt
@@ -1,0 +1,166 @@
+package kr.tekit.lion.presentation.schedulereview.vm
+
+import android.net.Uri
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import kr.tekit.lion.domain.exception.onError
+import kr.tekit.lion.domain.exception.onSuccess
+import kr.tekit.lion.domain.model.schedule.ModifiedScheduleReview
+import kr.tekit.lion.domain.model.schedule.ReviewImg
+import kr.tekit.lion.presentation.model.ReviewImage
+import kr.tekit.lion.domain.model.schedule.ScheduleReviewInfo
+import kr.tekit.lion.domain.repository.PlanRepository
+import kr.tekit.lion.domain.usecase.base.onError
+import kr.tekit.lion.domain.usecase.base.onSuccess
+import kr.tekit.lion.domain.usecase.plan.GetScheduleReviewInfoUseCase
+import kr.tekit.lion.presentation.delegate.NetworkErrorDelegate
+import javax.inject.Inject
+
+@HiltViewModel
+data class ModifyScheduleReviewViewModel @Inject constructor(
+    private val planRepository: PlanRepository,
+    private val getScheduleReviewUseCase: GetScheduleReviewInfoUseCase,
+) : ViewModel() {
+
+    @Inject
+    lateinit var networkErrorDelegate: NetworkErrorDelegate
+
+    // 이미지 url, uri, path
+    private val _imageList = MutableLiveData<List<ReviewImage>>()
+    val imageList: LiveData<List<ReviewImage>> get() = _imageList
+
+    private val _numOfImages = MutableLiveData<Int>(0)
+    val numOfImages: LiveData<Int> get() = _numOfImages
+
+    private val _originalReview = MutableLiveData<ScheduleReviewInfo>()
+    val originalReview: LiveData<ScheduleReviewInfo> get() = _originalReview
+
+    private val _deleteImgUrls = MutableLiveData<List<String>>()
+
+    fun addNewReviewImage(newImage: ReviewImage) {
+        val currentImageList = _imageList.value?.toMutableList() ?: mutableListOf<ReviewImage>()
+        currentImageList.add(newImage)
+        currentImageList.let { _imageList.value = it }
+
+        updateNumOfImages()
+    }
+
+    fun removeReviewImageFromList(position: Int) {
+        val imageUrl = _imageList.value?.get(position)?.imageUrl
+        if(imageUrl != null){
+            addDeletedImageUrl(imageUrl)
+        }
+
+        val currentImageList = _imageList.value?.toMutableList() ?: mutableListOf<ReviewImage>()
+        currentImageList.removeAt(position)
+        currentImageList.let { _imageList.value = it }
+
+        updateNumOfImages()
+    }
+
+    private fun addDeletedImageUrl(url: String) {
+        val currentUrlList = _deleteImgUrls.value?.toMutableList() ?: mutableListOf<String>()
+        currentUrlList.add(url)
+        currentUrlList.let { _deleteImgUrls.value = it }
+    }
+
+    private fun updateNumOfImages() {
+        _numOfImages.value = _imageList.value?.size ?: 0
+    }
+
+    fun isMoreImageAttachable(): Boolean {
+        val currentValue = _numOfImages.value ?: 0
+        return currentValue in 0..3
+    }
+
+    fun getScheduleReviewInfo(planId: Long) = viewModelScope.launch {
+        getScheduleReviewUseCase(planId)
+            .onSuccess {
+                _originalReview.value = it
+                initReviewImages()
+            }.onError {
+
+            }
+    }
+
+    private fun initReviewImages() {
+        _originalReview.value?.imageList?.let {
+            val reviewImages = it.map { imageUrl ->
+                ReviewImage(
+                    imageUrl = imageUrl,
+                    imageUri = Uri.parse(imageUrl),
+                    imagePath = null
+                )
+            }
+
+            _imageList.value = reviewImages
+            updateNumOfImages()
+        }
+    }
+
+    fun updateScheduleReview(
+        grade: Float,
+        content: String,
+        callback: (Boolean, Boolean) -> Unit
+    ) {
+        val newGrade = if (isGradeSame(grade)) null else grade
+        val newContent = if (isContentSame(content)) null else content
+        val deleteImgUrls = _deleteImgUrls.value
+
+        val modifiedReview = ModifiedScheduleReview(newGrade, newContent, deleteImgUrls)
+
+        val images = getNewImages()
+
+        _originalReview.value?.reviewId?.let { reviewId ->
+            viewModelScope.launch {
+                var requestFlag = false
+                val success = try {
+                    planRepository.modifyScheduleReview(reviewId, modifiedReview, images)
+                        .onSuccess {
+                            requestFlag = true
+                        }.onError {
+                            networkErrorDelegate.handleNetworkError(it)
+                        }
+                    true
+                } catch (e: Exception) {
+                    Log.d("updateScheduleReview", "Error: ${e.message}")
+                    false
+                }
+                callback(success, requestFlag)
+            }
+        }
+    }
+
+    private fun isContentSame(newContent: String) : Boolean {
+        return _originalReview.value?.content?.let {
+            it == newContent
+        } ?: true
+    }
+
+    private fun isGradeSame(newGrade: Float) : Boolean {
+        return _originalReview.value?.grade?.let {
+            it == newGrade
+        } ?: true
+    }
+
+    private fun getNewImages() : List<ReviewImg> {
+        val originalImageSize = _originalReview.value?.imageList?.size ?: 0
+        val deletedImageSize = _deleteImgUrls.value?.size ?: 0
+        val currentImageSize = _imageList.value?.size ?: 0
+
+        val startPoint = originalImageSize - deletedImageSize
+
+        val newImages = _imageList.value?.subList(startPoint, currentImageSize)
+
+        val newImagePaths = newImages?.mapNotNull { reviewImage ->
+            reviewImage.imagePath?.let { imagePath -> ReviewImg(path = imagePath) }
+        } ?: emptyList()
+
+        return newImagePaths
+    }
+}

--- a/DaOnGil/presentation/src/main/res/layout/activity_modify_schedule_review.xml
+++ b/DaOnGil/presentation/src/main/res/layout/activity_modify_schedule_review.xml
@@ -8,6 +8,293 @@
     android:background="@color/navi_background"
     tools:context=".schedulereview.ModifyScheduleReviewActivity">
 
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar_modify_schedule_review"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@color/navi_background"
+        android:minHeight="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navigationIcon="@drawable/cancel_icon">
 
+        <TextView
+            style="@style/Theme.Toolbar.Title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/text_modify_schedule_review" />
+
+    </com.google.android.material.appbar.MaterialToolbar>
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:fillViewport="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/toolbar_modify_schedule_review">
+
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/card_msr_schedule"
+                style="@style/Widget.Material3.CardView.Filled"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/margin_basic"
+                android:layout_marginTop="@dimen/margin_big4"
+                android:backgroundTint="@color/item_background"
+                app:cardCornerRadius="5dp"
+                app:cardElevation="4dp"
+                app:cardPreventCornerOverlap="true"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent">
+
+                    <View
+                        android:id="@+id/view_msr_deco"
+                        android:layout_width="5dp"
+                        android:layout_height="0dp"
+                        android:background="@color/primary"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <TextView
+                        android:id="@+id/text_msr_schedule_title"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginTop="@dimen/margin_big4"
+                        android:ellipsize="end"
+                        android:fontFamily="@font/pretendard_semibold"
+                        android:maxLines="1"
+                        android:textColor="@color/text_secondary"
+                        android:textSize="@dimen/font_big2"
+                        app:layout_constraintEnd_toEndOf="@+id/text_msr_schedule_period"
+                        app:layout_constraintStart_toStartOf="@+id/text_msr_schedule_period"
+                        app:layout_constraintTop_toTopOf="parent"
+                        tools:text="경주여행" />
+
+                    <TextView
+                        android:id="@+id/text_msr_schedule_period"
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_marginStart="@dimen/margin_big3"
+                        android:layout_marginTop="@dimen/margin_small2"
+                        android:layout_marginEnd="@dimen/margin_big3"
+                        android:layout_marginBottom="@dimen/margin_big4"
+                        android:fontFamily="@font/pretendard_light"
+                        android:textColor="@color/text_secondary"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toStartOf="@+id/image_msr_schedule_thumbnail"
+                        app:layout_constraintStart_toEndOf="@+id/view_msr_deco"
+                        app:layout_constraintTop_toBottomOf="@+id/text_msr_schedule_title"
+                        tools:text="2024.04.01 - 04.05" />
+
+                    <ImageView
+                        android:id="@+id/image_msr_schedule_thumbnail"
+                        android:layout_width="@dimen/search_bar_height"
+                        android:layout_height="@dimen/search_bar_height"
+                        android:layout_marginEnd="@dimen/margin_small1"
+                        android:contentDescription="@string/text_schedule_thumbnail_image"
+                        android:scaleType="centerCrop"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintTop_toTopOf="parent"
+                        app:srcCompat="@drawable/empty_view_small" />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <com.willy.ratingbar.BaseRatingBar
+                android:id="@+id/ratingbar_msr"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="@dimen/margin_big1"
+                android:contentDescription="@string/text_schedule_satisfaction"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/card_msr_schedule"
+                app:srb_drawableEmpty="@drawable/star_icon"
+                app:srb_drawableFilled="@drawable/star_filled_icon"
+                app:srb_isIndicator="false"
+                app:srb_minimumStars="0"
+                app:srb_numStars="5"
+                app:srb_rating="0"
+                app:srb_starHeight="40dp"
+                app:srb_starPadding="7dp"
+                app:srb_starWidth="40dp"
+                app:srb_stepSize="0.5" />
+
+            <View
+                android:id="@+id/view_msr_divider"
+                android:layout_width="wrap_content"
+                android:layout_height="10dp"
+                android:layout_marginTop="@dimen/margin_basic"
+                android:background="@drawable/dotted_line_horizontal"
+                android:layerType="software"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/ratingbar_msr" />
+
+            <TextView
+                android:id="@+id/text_msr_content"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_basic"
+                android:layout_marginTop="@dimen/margin_basic"
+                android:fontFamily="@font/pretendard_semibold"
+                android:text="@string/text_schedule_review"
+                android:textSize="@dimen/font_big3"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/view_msr_divider" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/text_input_msr_content"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/margin_basic"
+                android:layout_marginTop="@dimen/margin_big4"
+                android:textColorHint="@color/text_tertiary"
+                app:boxBackgroundColor="@color/text_box_background"
+                app:boxCornerRadiusBottomEnd="10dp"
+                app:boxCornerRadiusBottomStart="10dp"
+                app:boxCornerRadiusTopEnd="10dp"
+                app:boxCornerRadiusTopStart="10dp"
+                app:boxStrokeWidth="0dp"
+                app:errorEnabled="true"
+                app:hintEnabled="false"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/text_msr_content">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/edit_msr_content"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/pretendard_medium"
+                    android:gravity="top"
+                    android:hint="@string/hint_review_content"
+                    android:inputType="textMultiLine"
+                    android:lines="7"
+                    android:maxLines="7"
+                    android:text=""
+                    android:textColor="@color/text_primary"
+                    android:textColorHint="@color/text_tertiary"
+                    android:textSize="@dimen/font_small1" />
+
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <TextView
+                android:id="@+id/text_msr_photo"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_basic"
+                android:layout_marginTop="@dimen/margin_big1"
+                android:fontFamily="@font/pretendard_semibold"
+                android:text="@string/text_schedule_review_photo"
+                android:textSize="@dimen/font_big3"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/text_input_msr_content" />
+
+            <com.google.android.material.card.MaterialCardView
+                android:id="@+id/card_msr_add_photo"
+                android:layout_width="80dp"
+                android:layout_height="80dp"
+                android:layout_marginStart="@dimen/margin_basic"
+                android:layout_marginTop="@dimen/margin_big4"
+                app:cardCornerRadius="0dp"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/text_msr_photo"
+                app:layout_constraintVertical_bias="0"
+                app:strokeColor="@color/primary_disabled"
+                app:strokeWidth="1dp">
+
+                <androidx.constraintlayout.widget.ConstraintLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:background="@color/navi_background">
+
+                    <ImageButton
+                        android:id="@+id/button_msr_add_photo"
+                        android:layout_width="0dp"
+                        android:layout_height="0dp"
+                        android:background="@color/navi_background"
+                        android:paddingBottom="@dimen/margin_basic"
+                        android:src="@drawable/review_image_icon"
+                        android:contentDescription="@string/text_add_schedule_photo"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toStartOf="parent"
+                        app:layout_constraintTop_toTopOf="parent" />
+
+                    <TextView
+                        android:id="@+id/text_msr_photo_num"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="16dp"
+                        android:textColor="@color/days_remaining"
+                        android:textStyle="bold"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toStartOf="@+id/text_msr_photo_num_max"
+                        app:layout_constraintHorizontal_chainStyle="packed"
+                        app:layout_constraintStart_toStartOf="parent"
+                        tools:text="@string/text_num_of_images" />
+
+                    <TextView
+                        android:id="@+id/text_msr_photo_num_max"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginBottom="16dp"
+                        android:text="@string/text_num_of_max_images"
+                        android:textColor="@color/text_num_of_review_images"
+                        app:layout_constraintBottom_toBottomOf="parent"
+                        app:layout_constraintEnd_toEndOf="parent"
+                        app:layout_constraintStart_toEndOf="@+id/text_msr_photo_num" />
+
+                </androidx.constraintlayout.widget.ConstraintLayout>
+            </com.google.android.material.card.MaterialCardView>
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recycler_view_msr_photos"
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_marginStart="@dimen/margin_small1"
+                android:clipToPadding="false"
+                android:orientation="horizontal"
+                android:paddingEnd="@dimen/margin_basic"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                app:layout_constraintBottom_toBottomOf="@+id/card_msr_add_photo"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toEndOf="@+id/card_msr_add_photo"
+                app:layout_constraintTop_toTopOf="@+id/card_msr_add_photo" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.core.widget.NestedScrollView>
+
+    <Button
+        android:id="@+id/button_msr_submit"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/margin_basic"
+        android:layout_marginBottom="@dimen/margin_basic"
+        android:background="@drawable/background_radius_10"
+        android:fontFamily="@font/pretendard_bold"
+        android:text="@string/text_save_schedule_review"
+        android:textColor="@color/text_primary"
+        android:textSize="@dimen/font_small1"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintVertical_bias="1" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/DaOnGil/presentation/src/main/res/layout/activity_modify_schedule_review.xml
+++ b/DaOnGil/presentation/src/main/res/layout/activity_modify_schedule_review.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/navi_background"
+    tools:context=".schedulereview.ModifyScheduleReviewActivity">
+
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/DaOnGil/presentation/src/main/res/values/strings.xml
+++ b/DaOnGil/presentation/src/main/res/values/strings.xml
@@ -160,6 +160,7 @@
     <string name="text_birth_ex">예) 19700101</string>
     <string name="text_contact_ex">예) 01012345678</string>
 
+    <string name="text_modify_schedule_review">여행 후기 수정하기</string>
     <string name="text_write_schedule_review">여행 후기 남기기</string>
     <string name="text_schedule_review_photo">여행 사진</string>
     <string name="text_save_schedule_review">저장하기</string>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #98 

## 📝작업 내용

- 일정 후기 수정 기능 구현
- 일정 후기 수정 화면과 연결된 화면( 일정 상세보기 화면, 내 일정 목록 화면)과 연결

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
- 
https://github.com/user-attachments/assets/1630ed50-97d5-4c0f-ab60-0c219b386de6



## 💬리뷰 요구사항(선택)

- domian 레이어의 model 패키지에 ReviewImage(imageUrl: String, imageUri: Uri, imagePath: String) 데이터 클래스를 생성하려고 했는데,
```android.net.Uri``` 를 import할 수 없어서, presentation layer으로 옮겨서 생성했습니다.
data 레이어에서는 domain 레이어의 model 패키지에 있는 ReviewImg(imagePath: String만 호출하도록 수정했습니다.
이런 식으로 구현해도 되나요?  

- package kr.tekit.lion.domain.usecase.base.Result는 onError에서 Throwable을 전달해주고 있는데,
- package kr.tekit.lion.domain.exception.Result처럼 NetworkError 전달해주도록 변경도 가능한가요? 에러 처리 하는 코드를 넣으려고 했더니 이 부분에서 막혔습니다..
