### PR TITLE
[#109] 관광지 후기목록 게스트ver api 연결

### DIFF
--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/datasource/PlaceDataSource.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/datasource/PlaceDataSource.kt
@@ -94,4 +94,8 @@ internal class PlaceDataSource @Inject constructor(
     suspend fun getPlaceReviewList(placeId: Long, size: Int, page: Int) : Result<PlaceReviewInfo> = execute {
         placeService.getPlaceReviewList(placeId, size, page).toDomainModel()
     }
+
+    suspend fun getPlaceReviewListGuest(placeId: Long, size: Int, page: Int) : Result<PlaceReviewInfo> = execute {
+        placeService.getPlaceReviewListGuest(placeId, size, page).toDomainModel()
+    }
 }

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/placereviewlistguest/Data.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/placereviewlistguest/Data.kt
@@ -1,0 +1,17 @@
+package kr.tekit.lion.data.dto.response.placereviewlistguest
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import kr.tekit.lion.data.dto.response.placereviewlist.MyPlaceReview
+
+@JsonClass(generateAdapter = true)
+internal data class Data(
+    @Json(name = "myplaceReviewList")
+    val myPlaceReviewList: List<MyPlaceReview>,
+    val placeImg: String,
+    val pageNo: Int?,
+    val pageSize: Int?,
+    val placeAddress: String,
+    val placeName: String,
+    val totalPages: Int?
+)

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/placereviewlistguest/MyPlaceReviewGuest.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/placereviewlistguest/MyPlaceReviewGuest.kt
@@ -1,0 +1,16 @@
+package kr.tekit.lion.data.dto.response.placereviewlistguest
+
+import com.squareup.moshi.JsonClass
+import java.time.LocalDate
+
+@JsonClass(generateAdapter = true)
+internal data class MyPlaceReviewGuest (
+    val content: String,
+    val date: LocalDate,
+    val grade: Float,
+    val imageList: List<String>,
+    val nickname: String,
+    val profileImg: String,
+    val reviewId: Int,
+    val myReview: Boolean
+)

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/placereviewlistguest/PlaceReviewResponseGuest.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/placereviewlistguest/PlaceReviewResponseGuest.kt
@@ -1,0 +1,34 @@
+package kr.tekit.lion.data.dto.response.placereviewlistguest
+
+import kr.tekit.lion.data.dto.response.placereviewlist.Data
+import kr.tekit.lion.domain.model.placereviewlist.PlaceReview
+import kr.tekit.lion.domain.model.placereviewlist.PlaceReviewInfo
+
+internal data class PlaceReviewResponseGuest(
+    val code: Int,
+    val data: Data,
+    val message: String
+) {
+    fun toDomainModel(): PlaceReviewInfo {
+        return PlaceReviewInfo(
+            placeReviewList = data.myPlaceReviewList.map {
+                PlaceReview(
+                    content = it.content,
+                    date = it.date,
+                    grade = it.grade,
+                    imageList = it.imageList,
+                    nickname = it.nickname,
+                    profileImg = it.profileImg,
+                    reviewId = it.reviewId,
+                    myReview = it.myReview
+                )
+            },
+            placeImg = data.placeImg,
+            pageNo = data.pageNo,
+            pageSize = data.pageSize,
+            placeAddress = data.placeAddress,
+            placeName = data.placeName,
+            totalPages = data.totalPages
+        )
+    }
+}

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/repository/PlaceRepositoryImpl.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/repository/PlaceRepositoryImpl.kt
@@ -95,4 +95,8 @@ internal class PlaceRepositoryImpl @Inject constructor(
     override suspend fun getPlaceReviewList(placeId: Long, page: Int, size: Int): Result<PlaceReviewInfo> {
         return placeDataSource.getPlaceReviewList(placeId, page, size)
     }
+
+    override suspend fun getPlaceReviewListGuest(placeId: Long, page: Int, size: Int): Result<PlaceReviewInfo> {
+        return placeDataSource.getPlaceReviewListGuest(placeId, page, size)
+    }
 }

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/service/PlaceService.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/service/PlaceService.kt
@@ -7,6 +7,7 @@ import kr.tekit.lion.data.dto.response.detailplaceguest.DetailPlaceGuestResponse
 import kr.tekit.lion.data.dto.response.mainplace.MainPlaceResponse
 import kr.tekit.lion.data.dto.response.placereview.WritePlaceReviewResponse
 import kr.tekit.lion.data.dto.response.placereviewlist.PlaceReviewResponse
+import kr.tekit.lion.data.dto.response.placereviewlistguest.PlaceReviewResponseGuest
 import kr.tekit.lion.data.dto.response.searchplace.list.SearchPlaceResponse
 import kr.tekit.lion.data.dto.response.searchplace.map.MapSearchResponse
 import okhttp3.MultipartBody
@@ -78,7 +79,8 @@ internal interface PlaceService {
     @GET("place/main")
     suspend fun getPlaceMainInfo(
         @Query("areacode") areacode : String,
-        @Query("sigungucode") sigungucode : String
+        @Query("sigungucode") sigungucode : String,
+        @Tag authType: AuthType = AuthType.NO_AUTH
     ): MainPlaceResponse
 
     @GET("place/{placeId}")
@@ -108,4 +110,12 @@ internal interface PlaceService {
         @Query("page") page: Int,
         @Tag authType: AuthType = AuthType.ACCESS_TOKEN
     ): PlaceReviewResponse
+
+    @GET("place/review/{placeId}")
+    suspend fun getPlaceReviewListGuest(
+        @Path("placeId") placeId: Long,
+        @Query("size") size: Int,
+        @Query("page") page: Int,
+        @Tag authType: AuthType = AuthType.NO_AUTH
+    ): PlaceReviewResponseGuest
 }

--- a/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/repository/PlaceRepository.kt
+++ b/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/repository/PlaceRepository.kt
@@ -49,4 +49,6 @@ interface PlaceRepository {
 
     suspend fun getPlaceReviewList(placeId: Long, size: Int, page: Int): Result<PlaceReviewInfo>
 
+    suspend fun getPlaceReviewListGuest(placeId: Long, size: Int, page: Int): Result<PlaceReviewInfo>
+
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/DetailActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/DetailActivity.kt
@@ -113,11 +113,11 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
         }
     }
 
-    private fun settingModifyBtn(review: Review) {
+    private fun settingModifyBtn(review: Review, placeName: String) {
 
         binding.detailModifyReviewBtn.setOnClickListener {
             val intent = Intent(this, MyReviewActivity::class.java)
-            val reviewInfo = review.toReviewInfo()
+            val reviewInfo = review.toReviewInfo(placeName)
             intent.putExtra("reviewInfo", reviewInfo)
 
             startActivity(intent)
@@ -146,7 +146,7 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
             val myReview = it.filter { review -> review.myReview }
 
             myReview.forEach { review ->
-                settingModifyBtn(review)
+                settingModifyBtn(review, name)
             }
         }
 

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/ReviewListActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/ReviewListActivity.kt
@@ -13,9 +13,11 @@ import kr.tekit.lion.domain.model.placereviewlist.PlaceReview
 import kr.tekit.lion.presentation.R
 import kr.tekit.lion.presentation.databinding.ActivityReviewListBinding
 import kr.tekit.lion.presentation.ext.addOnScrollEndListener
+import kr.tekit.lion.presentation.ext.repeatOnStarted
 import kr.tekit.lion.presentation.home.adapter.ReviewListRVAdapter
 import kr.tekit.lion.presentation.home.vm.ReviewListViewModel
 import kr.tekit.lion.presentation.main.dialog.ConfirmDialog
+import kr.tekit.lion.presentation.splash.model.LogInState
 
 @AndroidEntryPoint
 class ReviewListActivity : AppCompatActivity() {
@@ -31,7 +33,25 @@ class ReviewListActivity : AppCompatActivity() {
         val placeId = intent.getLongExtra("reviewPlaceId", -1)
 
         settingToolbar()
-        getReviewListInfo(placeId)
+
+        repeatOnStarted {
+            viewModel.loginState.collect { uiState ->
+                when (uiState) {
+                    is LogInState.Checking -> {
+                        return@collect
+                    }
+
+                    is LogInState.LoggedIn -> {
+                        getReviewListInfo(placeId)
+                    }
+
+                    is LogInState.LoginRequired -> {
+                        getReviewListInfoGuest(placeId)
+                    }
+                }
+            }
+        }
+
     }
 
     private fun settingToolbar() {
@@ -62,6 +82,29 @@ class ReviewListActivity : AppCompatActivity() {
         binding.reviewListRv.addOnScrollEndListener {
             if (viewModel.isLastPage.value == false) {
                 viewModel.getNewPlaceReview(placeId)
+            }
+        }
+
+        viewModel.placeReviewInfo.observe(this@ReviewListActivity) { placeReviewInfo ->
+            binding.reviewListTitleTv.text = placeReviewInfo.placeName
+            binding.reviewListAddressTv.text = placeReviewInfo.placeAddress
+            binding.reviewListCount2Tv.text = placeReviewInfo.placeReviewList.size.toString()
+
+            Glide.with(binding.reviewListThumbnailIv)
+                .load(placeReviewInfo.placeImg)
+                .error(R.drawable.empty_view)
+                .into(binding.reviewListThumbnailIv)
+
+            settingReviewListRVAdapter(placeReviewInfo.placeReviewList)
+        }
+    }
+
+    private fun getReviewListInfoGuest(placeId : Long) {
+        viewModel.getPlaceReviewGuest(placeId)
+
+        binding.reviewListRv.addOnScrollEndListener {
+            if (viewModel.isLastPage.value == false) {
+                viewModel.getNewPlaceReviewGuest(placeId)
             }
         }
 

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/model/ReviewInfo.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/model/ReviewInfo.kt
@@ -14,10 +14,11 @@ data class ReviewInfo (
     val reviewImgs : List<String>?,
     val grade : Float,
     val date : LocalDate,
-    val myReview : Boolean
+    val myReview : Boolean,
+    val placeName: String
 ): Parcelable
 
-fun Review.toReviewInfo(): ReviewInfo {
+fun Review.toReviewInfo(placeName: String): ReviewInfo {
     return ReviewInfo(
         reviewId = this.reviewId,
         nickname = this.nickname,
@@ -26,6 +27,7 @@ fun Review.toReviewInfo(): ReviewInfo {
         reviewImgs = this.reviewImgs,
         grade = this.grade,
         date = this.date,
-        myReview = this.myReview
+        myReview = this.myReview,
+        placeName = placeName
     )
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/vm/ReviewListViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/vm/ReviewListViewModel.kt
@@ -1,26 +1,33 @@
 package kr.tekit.lion.presentation.home.vm
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import kr.tekit.lion.domain.exception.onError
 import kr.tekit.lion.domain.exception.onSuccess
 import kr.tekit.lion.domain.model.placereviewlist.PlaceReviewInfo
+import kr.tekit.lion.domain.repository.AuthRepository
 import kr.tekit.lion.domain.repository.PlaceRepository
 import kr.tekit.lion.presentation.delegate.NetworkErrorDelegate
+import kr.tekit.lion.presentation.splash.model.LogInState
 import javax.inject.Inject
 
 @HiltViewModel
 class ReviewListViewModel @Inject constructor(
+    private val authRepository: AuthRepository,
     private val getPlaceReviewListRepository: PlaceRepository
 ) : ViewModel() {
 
     @Inject
     lateinit var networkErrorDelegate: NetworkErrorDelegate
+
+    private val _loginState = MutableStateFlow<LogInState>(LogInState.Checking)
+    val loginState = _loginState.asStateFlow()
 
     private val _placeReviewInfo = MutableLiveData<PlaceReviewInfo>()
     val placeReviewInfo : LiveData<PlaceReviewInfo> = _placeReviewInfo
@@ -34,10 +41,29 @@ class ReviewListViewModel @Inject constructor(
 
     init {
         _isLastPage.value = false
+
+        viewModelScope.launch {
+            checkLoginState()
+        }
+    }
+
+    private suspend fun checkLoginState(){
+        authRepository.loggedIn.collect{ isLoggedIn ->
+            if (isLoggedIn) _loginState.value = LogInState.LoggedIn
+            else _loginState.value = LogInState.LoginRequired
+        }
     }
 
     fun getPlaceReview(placeId: Long) = viewModelScope.launch {
         getPlaceReviewListRepository.getPlaceReviewList(placeId, PAGE_SIZE, 0).onSuccess {
+            _placeReviewInfo.value = it
+        }.onError {
+            networkErrorDelegate.handleNetworkError(it)
+        }
+    }
+
+    fun getPlaceReviewGuest(placeId: Long) = viewModelScope.launch {
+        getPlaceReviewListRepository.getPlaceReviewListGuest(placeId, PAGE_SIZE, 0).onSuccess {
             _placeReviewInfo.value = it
         }.onError {
             networkErrorDelegate.handleNetworkError(it)
@@ -49,6 +75,26 @@ class ReviewListViewModel @Inject constructor(
 
         if (page != null) {
             getPlaceReviewListRepository.getPlaceReviewList(placeId, size = PAGE_SIZE, page = page + 1).onSuccess {
+                if (it.pageNo == it.totalPages) {
+                    _isLastPage.value = true
+                } else {
+                    val reviews = _placeReviewInfo.value?.placeReviewList ?: emptyList()
+                    val newReviews = reviews + it.placeReviewList
+                    val newReviewData = it.copy(placeReviewList = newReviews)
+
+                    _placeReviewInfo.value = newReviewData
+                }
+            }.onError {
+                networkErrorDelegate.handleNetworkError(it)
+            }
+        }
+    }
+
+    fun getNewPlaceReviewGuest(placeId: Long) = viewModelScope.launch {
+        val page = _placeReviewInfo.value?.pageNo
+
+        if (page != null) {
+            getPlaceReviewListRepository.getPlaceReviewListGuest(placeId, size = PAGE_SIZE, page = page + 1).onSuccess {
                 if (it.pageNo == it.totalPages) {
                     _isLastPage.value = true
                 } else {


### PR DESCRIPTION
## #️⃣연관된 이슈

- #109 

## 📝작업 내용

- 관광지 후기목록 API가 게스트ver/로그인ver로 나눠져서 게스트ver 추가했습니다

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
- 지금 게스트 버전으로 실행 시 갑자기 메인화면 데이터가 안떠서 다시 알아보도록 하겠습니다 ,, !

## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  - 정민언니 파트로 이어지는 관광지 상세보기에서 수정 화면으로 이동 시 추가해달라고 한 데이터 추가도 같이 진행했습니다 !
