### PR TITLE
[#108] 관광지 상세보기 수정하기 화면 이동 구현

### DIFF
--- a/DaOnGil/.idea/other.xml
+++ b/DaOnGil/.idea/other.xml
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="direct_access_persist.xml">
+    <option name="deviceSelectionList">
+      <list>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="27" />
+          <option name="brand" value="DOCOMO" />
+          <option name="codename" value="F01L" />
+          <option name="id" value="F01L" />
+          <option name="manufacturer" value="FUJITSU" />
+          <option name="name" value="F-01L" />
+          <option name="screenDensity" value="360" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1280" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="28" />
+          <option name="brand" value="DOCOMO" />
+          <option name="codename" value="SH-01L" />
+          <option name="id" value="SH-01L" />
+          <option name="manufacturer" value="SHARP" />
+          <option name="name" value="AQUOS sense2 SH-01L" />
+          <option name="screenDensity" value="480" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2160" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="31" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="a51" />
+          <option name="id" value="a51" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy A51" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="google" />
+          <option name="codename" value="akita" />
+          <option name="id" value="akita" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 8a" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="b0q" />
+          <option name="id" value="b0q" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S22 Ultra" />
+          <option name="screenDensity" value="600" />
+          <option name="screenX" value="1440" />
+          <option name="screenY" value="3088" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="32" />
+          <option name="brand" value="google" />
+          <option name="codename" value="bluejay" />
+          <option name="id" value="bluejay" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 6a" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="google" />
+          <option name="codename" value="caiman" />
+          <option name="id" value="caiman" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 9 Pro" />
+          <option name="screenDensity" value="360" />
+          <option name="screenX" value="960" />
+          <option name="screenY" value="2142" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="google" />
+          <option name="codename" value="comet" />
+          <option name="id" value="comet" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 9 Pro Fold" />
+          <option name="screenDensity" value="390" />
+          <option name="screenX" value="2076" />
+          <option name="screenY" value="2152" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="29" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="crownqlteue" />
+          <option name="id" value="crownqlteue" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Note9" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="2220" />
+          <option name="screenY" value="1080" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="dm3q" />
+          <option name="id" value="dm3q" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S23 Ultra" />
+          <option name="screenDensity" value="600" />
+          <option name="screenX" value="1440" />
+          <option name="screenY" value="3088" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="e1q" />
+          <option name="id" value="e1q" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S24" />
+          <option name="screenDensity" value="480" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="google" />
+          <option name="codename" value="felix" />
+          <option name="id" value="felix" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel Fold" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="2208" />
+          <option name="screenY" value="1840" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="google" />
+          <option name="codename" value="felix" />
+          <option name="id" value="felix" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel Fold" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="2208" />
+          <option name="screenY" value="1840" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="google" />
+          <option name="codename" value="felix_camera" />
+          <option name="id" value="felix_camera" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel Fold (Camera-enabled)" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="2208" />
+          <option name="screenY" value="1840" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="gts8uwifi" />
+          <option name="id" value="gts8uwifi" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Tab S8 Ultra" />
+          <option name="screenDensity" value="320" />
+          <option name="screenX" value="1848" />
+          <option name="screenY" value="2960" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="google" />
+          <option name="codename" value="husky" />
+          <option name="id" value="husky" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 8 Pro" />
+          <option name="screenDensity" value="390" />
+          <option name="screenX" value="1008" />
+          <option name="screenY" value="2244" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="30" />
+          <option name="brand" value="motorola" />
+          <option name="codename" value="java" />
+          <option name="id" value="java" />
+          <option name="manufacturer" value="Motorola" />
+          <option name="name" value="G20" />
+          <option name="screenDensity" value="280" />
+          <option name="screenX" value="720" />
+          <option name="screenY" value="1600" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="google" />
+          <option name="codename" value="komodo" />
+          <option name="id" value="komodo" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 9 Pro XL" />
+          <option name="screenDensity" value="360" />
+          <option name="screenX" value="1008" />
+          <option name="screenY" value="2244" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="google" />
+          <option name="codename" value="lynx" />
+          <option name="id" value="lynx" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 7a" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="31" />
+          <option name="brand" value="google" />
+          <option name="codename" value="oriole" />
+          <option name="id" value="oriole" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 6" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="google" />
+          <option name="codename" value="panther" />
+          <option name="id" value="panther" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 7" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="q5q" />
+          <option name="id" value="q5q" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy Z Fold5" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1812" />
+          <option name="screenY" value="2176" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="30" />
+          <option name="brand" value="google" />
+          <option name="codename" value="r11" />
+          <option name="id" value="r11" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel Watch" />
+          <option name="screenDensity" value="320" />
+          <option name="screenX" value="384" />
+          <option name="screenY" value="384" />
+          <option name="type" value="WEAR_OS" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="30" />
+          <option name="brand" value="google" />
+          <option name="codename" value="redfin" />
+          <option name="id" value="redfin" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 5" />
+          <option name="screenDensity" value="440" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2340" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="google" />
+          <option name="codename" value="shiba" />
+          <option name="id" value="shiba" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 8" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2400" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="33" />
+          <option name="brand" value="google" />
+          <option name="codename" value="tangorpro" />
+          <option name="id" value="tangorpro" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel Tablet" />
+          <option name="screenDensity" value="320" />
+          <option name="screenX" value="1600" />
+          <option name="screenY" value="2560" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="34" />
+          <option name="brand" value="google" />
+          <option name="codename" value="tokay" />
+          <option name="id" value="tokay" />
+          <option name="manufacturer" value="Google" />
+          <option name="name" value="Pixel 9" />
+          <option name="screenDensity" value="420" />
+          <option name="screenX" value="1080" />
+          <option name="screenY" value="2424" />
+        </PersistentDeviceSelectionData>
+        <PersistentDeviceSelectionData>
+          <option name="api" value="29" />
+          <option name="brand" value="samsung" />
+          <option name="codename" value="x1q" />
+          <option name="id" value="x1q" />
+          <option name="manufacturer" value="Samsung" />
+          <option name="name" value="Galaxy S20" />
+          <option name="screenDensity" value="480" />
+          <option name="screenX" value="1440" />
+          <option name="screenY" value="3200" />
+        </PersistentDeviceSelectionData>
+      </list>
+    </option>
+  </component>
+</project>

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/DetailActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/DetailActivity.kt
@@ -116,10 +116,11 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
     private fun settingModifyBtn(review: Review, placeName: String) {
 
         binding.detailModifyReviewBtn.setOnClickListener {
-            val intent = Intent(this, MyReviewActivity::class.java)
-            val reviewInfo = review.toReviewInfo(placeName)
-            intent.putExtra("reviewInfo", reviewInfo)
-
+            val intent = Intent(this, MyReviewActivity::class.java).apply {
+                val reviewInfo = review.toReviewInfo(placeName)
+                putExtra("reviewInfo", reviewInfo)
+                putExtra("isModifyFromDetail", true)
+            }
             startActivity(intent)
         }
 

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/model/ReviewInfo.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/model/ReviewInfo.kt
@@ -2,6 +2,7 @@ package kr.tekit.lion.presentation.home.model
 
 import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
+import kr.tekit.lion.domain.model.MyPlaceReviewInfo
 import kr.tekit.lion.domain.model.detailplace.Review
 import java.time.LocalDate
 
@@ -29,5 +30,17 @@ fun Review.toReviewInfo(placeName: String): ReviewInfo {
         date = this.date,
         myReview = this.myReview,
         placeName = placeName
+    )
+}
+
+fun ReviewInfo.toMyPlaceReviewInfo(): MyPlaceReviewInfo {
+    return MyPlaceReviewInfo(
+        reviewId = this.reviewId,
+        placeId = 0,
+        grade = this.grade,
+        name = this.placeName,
+        date = this.date,
+        images = this.reviewImgs ?: emptyList(),
+        content = this.content
     )
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myreview/MyReviewActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myreview/MyReviewActivity.kt
@@ -1,17 +1,47 @@
 package kr.tekit.lion.presentation.myreview
 
+import android.os.Build
 import android.os.Bundle
-import androidx.activity.enableEdgeToEdge
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
+import androidx.navigation.fragment.NavHostFragment
 import dagger.hilt.android.AndroidEntryPoint
 import kr.tekit.lion.presentation.R
+import kr.tekit.lion.presentation.home.model.ReviewInfo
+import kr.tekit.lion.presentation.myreview.fragment.MyReviewFragment
+import kr.tekit.lion.presentation.myreview.fragment.MyReviewModifyFragment
+import kr.tekit.lion.presentation.myreview.vm.MyReviewViewModel
 
 @AndroidEntryPoint
 class MyReviewActivity : AppCompatActivity() {
+
+    private val viewModel: MyReviewViewModel by viewModels()
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_my_review)
+
+        val isFromDetail = intent.getBooleanExtra("isModifyFromDetail", false)
+        viewModel.setIsFromDetail(isFromDetail)
+
+        if (isFromDetail) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                val reviewInfo = intent.getParcelableExtra("reviewInfo", ReviewInfo::class.java)
+                if (reviewInfo != null) {
+                    viewModel.setDetailReviewData(reviewInfo)
+                }
+            } else {
+                @Suppress("DEPRECATION")
+                val reviewInfo = intent.getParcelableExtra<ReviewInfo>("reviewInfo")
+                if (reviewInfo != null) {
+                    viewModel.setDetailReviewData(reviewInfo)
+                }
+            }
+
+            val navHostFragment = supportFragmentManager.findFragmentById(R.id.fragmentContainerViewMyReview) as NavHostFragment
+            val navController = navHostFragment.navController
+
+            navController.navigate(R.id.myReviewModifyFragment)
+        }
     }
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myreview/fragment/MyReviewFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myreview/fragment/MyReviewFragment.kt
@@ -29,11 +29,21 @@ class MyReviewFragment : Fragment(R.layout.fragment_my_review) {
 
         val binding = FragmentMyReviewBinding.bind(view)
 
+        observeIsFromDetail()
+
         settingToolbar(binding)
         settingMyReviewRVAdapter(binding)
 
         requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
             handleBackPress()
+        }
+    }
+
+    private fun observeIsFromDetail() {
+        viewModel.isFromDetail.observe(viewLifecycleOwner) { isFromDetail ->
+            if (!isFromDetail) {
+                viewModel.getMyPlaceReview()
+            }
         }
     }
 

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myreview/fragment/MyReviewModifyFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myreview/fragment/MyReviewModifyFragment.kt
@@ -133,7 +133,11 @@ class MyReviewModifyFragment : Fragment(R.layout.fragment_my_review_modify) {
 
     private fun settingToolbar(binding: FragmentMyReviewModifyBinding) {
         binding.toolbarMyReviewModify.setNavigationOnClickListener {
-            findNavController().popBackStack()
+            if (viewModel.isFromDetail.value == true) {
+                requireActivity().finish()
+            } else {
+                findNavController().popBackStack()
+            }
         }
     }
 
@@ -163,9 +167,13 @@ class MyReviewModifyFragment : Fragment(R.layout.fragment_my_review_modify) {
 
                 viewModel.updateMyPlaceReview(viewModel.reviewData.value?.reviewId ?:0, grade, date!!, content)
 
-                requireContext().showSnackbar(requireView(), "여행지 후기가 수정되었습니다.")
+                if(viewModel.isFromDetail.value == true) {
+                    requireActivity().finish()
+                } else {
+                    requireContext().showSnackbar(requireView(), "여행지 후기가 수정되었습니다.")
 
-                findNavController().popBackStack()
+                    findNavController().popBackStack()
+                }
             }
         }
     }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myreview/vm/MyReviewViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myreview/vm/MyReviewViewModel.kt
@@ -3,6 +3,7 @@ package kr.tekit.lion.presentation.myreview.vm
 import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -15,6 +16,8 @@ import kr.tekit.lion.domain.model.MyPlaceReviewInfo
 import kr.tekit.lion.domain.model.UpdateMyPlaceReview
 import kr.tekit.lion.domain.repository.PlaceRepository
 import kr.tekit.lion.presentation.delegate.NetworkErrorDelegate
+import kr.tekit.lion.presentation.home.model.ReviewInfo
+import kr.tekit.lion.presentation.home.model.toMyPlaceReviewInfo
 import java.time.LocalDate
 import javax.inject.Inject
 
@@ -53,13 +56,12 @@ class MyReviewViewModel @Inject constructor(
     private val _isReviewDelete = MutableLiveData(false)
     val isReviewDelete: LiveData<Boolean> = _isReviewDelete
 
+    private val _isFromDetail = MutableLiveData(false)
+    val isFromDetail: LiveData<Boolean> = _isFromDetail
+
     private var isRequesting = false
 
-    init {
-        getMyPlaceReview()
-    }
-
-    private fun getMyPlaceReview(size: Int = REVIEW_GET_SIZE, page: Int = INITIAL_PAGE_NO) = viewModelScope.launch {
+    fun getMyPlaceReview(size: Int = REVIEW_GET_SIZE, page: Int = INITIAL_PAGE_NO) = viewModelScope.launch {
         placeRepository.getMyPlaceReview(size, page).onSuccess {
             _myPlaceReview.value = it
 
@@ -157,6 +159,14 @@ class MyReviewViewModel @Inject constructor(
         _visitDate.value = review.date
 
         updateNumOfImages()
+    }
+
+    fun setIsFromDetail(isModifyFromDetail: Boolean) {
+        _isFromDetail.value = isModifyFromDetail
+    }
+
+    fun setDetailReviewData(review: ReviewInfo) {
+        setReviewData(review.toMyPlaceReviewInfo())
     }
 
     fun setVisitDate(startDate: LocalDate) {


### PR DESCRIPTION
## #️⃣연관된 이슈

- #108 

## 📝작업 내용

- 관광지 상세보기에서 후기 수정하기 화면으로 이동 및 뷰모델에 데이터 설정
- 네비게에션 설정(app:startDestination)으로 인해 후기 목록 api 호출을 수정 모드 관찰하여 호출하도록 변경 

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)

https://github.com/user-attachments/assets/6d2d9dbf-d126-4ee1-a2c9-a158b05f8119



## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  
  
  
