### PR TITLE
[#118] 내 일정 목록 페이징 오류 수정

### DIFF
--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleUpcoming/MyUpcomingsResponse.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleUpcoming/MyUpcomingsResponse.kt
@@ -19,8 +19,7 @@ internal data class MyUpcomingsResponse(
                     startDate = it.startDate,
                     endDate = it.endDate,
                     imageUrl = it.imageUrl ?: "",
-                    //remainDate = it.remainDate
-                    remainDate = "D-1"
+                    remainDate = it.remainDate
                 )
             },
             last = data.last

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleUpcoming/PlanRes.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/dto/response/plan/myScheduleUpcoming/PlanRes.kt
@@ -9,5 +9,5 @@ internal data class PlanRes(
     val startDate: String,
     val endDate: String,
     val imageUrl: String?,
-    // val remainDate: String,
+     val remainDate: String,
 )

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myschedule/MyScheduleActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myschedule/MyScheduleActivity.kt
@@ -30,9 +30,11 @@ class MyScheduleActivity : AppCompatActivity() {
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
             if(result.resultCode == RESULT_CANCELED) return@registerForActivityResult
 
+            // 일정 목록 갱신
+            viewModel.refreshScheduleList()
+
             when (result.resultCode) {
                 ResultCode.RESULT_REVIEW_WRITE -> {
-                    viewModel.refreshScheduleList()
                     binding.root.showSnackbar("후기가 저장되었습니다")
                 }
             }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myschedule/MyScheduleActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myschedule/MyScheduleActivity.kt
@@ -28,10 +28,11 @@ class MyScheduleActivity : AppCompatActivity() {
 
     private val scheduleLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-            viewModel.getMyUpcomingScheduleList(0)
-            viewModel.getMyElapsedScheduleList(0)
+            if(result.resultCode == RESULT_CANCELED) return@registerForActivityResult
+
             when (result.resultCode) {
                 ResultCode.RESULT_REVIEW_WRITE -> {
+                    viewModel.refreshScheduleList()
                     binding.root.showSnackbar("후기가 저장되었습니다")
                 }
             }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myschedule/vm/MyScheduleViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myschedule/vm/MyScheduleViewModel.kt
@@ -54,7 +54,12 @@ class MyScheduleViewModel @Inject constructor(
         viewModelScope.launch {
             planRepository.getMyUpcomingScheduleList(page)
                 .onSuccess {
-                    val newList = _upcomingSchedules.value.orEmpty() + it.myUpcomingScheduleList
+                    val newList = if(page == INITIAL_PAGE_NO){
+                        it.myUpcomingScheduleList
+                    }else{
+                        _upcomingSchedules.value.orEmpty() + it.myUpcomingScheduleList
+                    }
+//                    val newList = _upcomingSchedules.value.orEmpty() + it.myUpcomingScheduleList
                     _upcomingSchedules.value = newList
                     _isLastUpcoming.value = it.last
                 }.onError {
@@ -68,7 +73,12 @@ class MyScheduleViewModel @Inject constructor(
         viewModelScope.launch {
             planRepository.getMyElapsedScheduleList(page)
                 .onSuccess {
-                    val newList = _elapsedSchedules.value.orEmpty() + it.myElapsedScheduleList
+                    val newList = if(page == INITIAL_PAGE_NO){
+                        it.myElapsedScheduleList
+                    }else{
+                        _elapsedSchedules.value.orEmpty() + it.myElapsedScheduleList
+                    }
+//                    val newList = _elapsedSchedules.value.orEmpty() + it.myElapsedScheduleList
                     _elapsedSchedules.value = newList
                     _isLastElapsed.value = it.last
                 }.onError {
@@ -107,5 +117,10 @@ class MyScheduleViewModel @Inject constructor(
         pageNo?.let {
             getMyElapsedScheduleList(it+1)
         }
+    }
+
+    fun refreshScheduleList(){
+        getMyUpcomingScheduleList(INITIAL_PAGE_NO)
+        getMyElapsedScheduleList(INITIAL_PAGE_NO)
     }
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myschedule/vm/MyScheduleViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myschedule/vm/MyScheduleViewModel.kt
@@ -59,7 +59,6 @@ class MyScheduleViewModel @Inject constructor(
                     }else{
                         _upcomingSchedules.value.orEmpty() + it.myUpcomingScheduleList
                     }
-//                    val newList = _upcomingSchedules.value.orEmpty() + it.myUpcomingScheduleList
                     _upcomingSchedules.value = newList
                     _isLastUpcoming.value = it.last
                 }.onError {
@@ -78,7 +77,6 @@ class MyScheduleViewModel @Inject constructor(
                     }else{
                         _elapsedSchedules.value.orEmpty() + it.myElapsedScheduleList
                     }
-//                    val newList = _elapsedSchedules.value.orEmpty() + it.myElapsedScheduleList
                     _elapsedSchedules.value = newList
                     _isLastElapsed.value = it.last
                 }.onError {

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myschedule/vm/MyScheduleViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myschedule/vm/MyScheduleViewModel.kt
@@ -49,7 +49,7 @@ class MyScheduleViewModel @Inject constructor(
         _elapsedPageNo.value = pageNum
     }
 
-    fun getMyUpcomingScheduleList(page: Int) {
+    private fun getMyUpcomingScheduleList(page: Int) {
         setUpcomingPageNo(page)
         viewModelScope.launch {
             planRepository.getMyUpcomingScheduleList(page)
@@ -67,7 +67,7 @@ class MyScheduleViewModel @Inject constructor(
         }
     }
 
-    fun getMyElapsedScheduleList(page: Int) {
+    private fun getMyElapsedScheduleList(page: Int) {
         setElapsedPageNo(page)
         viewModelScope.launch {
             planRepository.getMyElapsedScheduleList(page)


### PR DESCRIPTION
## #️⃣연관된 이슈

- #118 

## 📝작업 내용

- 내 일정 목록 화면에서 다른 화면(일정 상세보기 화면이나 일정 후기 등록화면)으로 전환한 뒤 돌아왔을 때 일정을 새롭게 호출했습니다.
- 이 때, 처음 불러온 목록이 남아있어서 계속해서 똑같은 일정들이 반복해서 쌓이는 문제가 있었습니다.
- 여행 후기가 작성되었을 때만 일정 목록을 새롭게 호출할 수 있게 수정했습니다.

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)

https://github.com/user-attachments/assets/3d3ebd7a-705c-4032-bab0-3a6077ab3f86

https://github.com/user-attachments/assets/8557078d-18c5-4719-bbbc-135d9096710d



## 💬리뷰 요구사항(선택)

- 일정 목록 -> 일정 상세보기 -> 일정 수정 -> 일정 상세보기 -> 일정 목록
이런 식으로 화면 이동을 하면, 일정 목록을 새롭게 갱신하진 않는데, 
매번 다른 화면에서 돌아올 때마다 목록을 갱신해주는 게 좋을까요? 

