### PR TITLE
[#139] 일정 - 여행지 검색 화면 프로그래스바 에러처리

### DIFF
--- a/DaOnGil/presentation/src/main/res/layout/fragment_form_search.xml
+++ b/DaOnGil/presentation/src/main/res/layout/fragment_form_search.xml
@@ -35,6 +35,7 @@
             app:backgroundTint="@color/primary_disabled" />
 
         <TextView
+            android:id="@+id/text_fs_bookmark_title"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="@dimen/margin_basic"
@@ -49,7 +50,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_big3"
             android:paddingHorizontal="@dimen/margin_basic"
-            android:visibility="visible" />
+            android:visibility="gone" />
 
         <TextView
             android:id="@+id/text_fs_bookmark_empty"
@@ -64,6 +65,30 @@
             android:textSize="@dimen/font_big3"
             android:visibility="gone"
             app:drawableTopCompat="@drawable/onboarding_clover" />
+
+        <TextView
+            android:id="@+id/text_fs_bookmark_error"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="100dp"
+            android:layout_weight="1"
+            android:fontFamily="@font/cafe24_oneprettynight"
+            android:gravity="center_horizontal"
+            android:lineSpacingMultiplier="1.5"
+            android:textAlignment="center"
+            android:textSize="@dimen/font_big1"
+            android:visibility="gone"
+            app:drawableTopCompat="@drawable/onboarding_clover" />
+
+        <ProgressBar
+            android:id="@+id/progressBar_fs_bookmark"
+            android:layout_width="150dp"
+            android:layout_height="150dp"
+            android:layout_gravity="center"
+            android:layout_weight="1"
+            android:foregroundGravity="center"
+            android:indeterminateDrawable="@drawable/rotate_progress_bar"
+            android:visibility="visible" />
 
     </LinearLayout>
 
@@ -96,6 +121,28 @@
             android:textSize="@dimen/font_big3"
             android:visibility="gone"
             app:drawableTopCompat="@drawable/onboarding_clover" />
+
+        <TextView
+            android:id="@+id/text_fs_result_error"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginBottom="100dp"
+            android:fontFamily="@font/cafe24_oneprettynight"
+            android:gravity="center_horizontal"
+            android:lineSpacingMultiplier="1.5"
+            android:textAlignment="center"
+            android:textSize="@dimen/font_big1"
+            android:visibility="gone"
+            app:drawableTopCompat="@drawable/onboarding_clover" />
+
+        <ProgressBar
+            android:id="@+id/progressBar_fs_result"
+            android:layout_width="150dp"
+            android:layout_height="150dp"
+            android:layout_gravity="center"
+            android:indeterminateDrawable="@drawable/rotate_progress_bar"
+            android:visibility="gone" />
 
     </com.google.android.material.search.SearchView>
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #139

## 📝작업 내용

- 일정 등록 화면에 있는 여행지 검색 화면 프로그래스바, 네트워크 에러 처리 작업했습니다.
- 북마크 목록, 여행지 검색 결과 두 개의 API중 하나만 오류날 상황도 있을 것 같아서 progressBar, 에러 메시지 각각 처리했습니다. 

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
### 에러 발생하는 상황
https://github.com/user-attachments/assets/8b04bd7c-1162-47d8-910c-8aacdf505594

### 에러 발생했지만, 다시 복구된 상황
https://github.com/user-attachments/assets/00d9899e-2bae-4228-aae4-2b2fccc0d90d



## 💬리뷰 요구사항(선택)

- 
