### PR TITLE
[#149] 사용자 로그아웃 api 구현

### DIFF
--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/datasource/AuthDataSource.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/datasource/AuthDataSource.kt
@@ -33,4 +33,13 @@ internal class AuthDataSource @Inject constructor(
 
         if (refreshToken.isNotBlank()) authService.refresh(refreshToken) else null
     }
+
+    private suspend fun localLogout() {
+        dataStore.updateData {
+            it.copy(
+                accessToken = "",
+                refreshToken = "",
+            )
+        }
+    }
 }

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/datasource/AuthDataSource.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/datasource/AuthDataSource.kt
@@ -28,6 +28,12 @@ internal class AuthDataSource @Inject constructor(
         authService.signIn(type = type, token = token)
     }
 
+    suspend fun logout(): Result<Unit> = runCatching {
+        val accessToken = data.map { it.accessToken }.first()
+        localLogout()
+        authService.signOut("Bearer $accessToken")
+    }
+
     suspend fun refresh(): Result<SignUpResponse?> = runCatching {
         val refreshToken = data.map { it.refreshToken }.first()
 

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/repository/AuthRepositoryImpl.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/repository/AuthRepositoryImpl.kt
@@ -22,4 +22,6 @@ internal class AuthRepositoryImpl @Inject constructor(
             it.printStackTrace()
         }
     }
+
+    override suspend fun logout(): Result<Unit> = authDataSource.logout()
 }

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/service/AuthAuthenticator.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/service/AuthAuthenticator.kt
@@ -48,7 +48,7 @@ internal class AuthAuthenticator @Inject constructor(
             )
             it.accessToken
         } ?: run {
-            //authDataSource.logout()
+            authDataSource.logout()
             null
         }
     }

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/service/AuthService.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/service/AuthService.kt
@@ -15,9 +15,9 @@ internal interface AuthService {
         @Tag authType: AuthType = AuthType.NO_AUTH
     ): SignInResponse
 
-    @POST("auth/sign-in")
-    suspend fun login(
-        @Query("type") type: String,
+    @POST("auth/sign-out")
+    suspend fun signOut(
+        @Header("Authorization") token: String,
         @Tag authType: AuthType = AuthType.ACCESS_TOKEN
     ): SignInResponse
 

--- a/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/repository/AuthRepository.kt
+++ b/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/repository/AuthRepository.kt
@@ -4,5 +4,6 @@ import kotlinx.coroutines.flow.Flow
 
 interface AuthRepository {
     suspend fun signIn(type: String, token: String)
+    suspend fun logout(): Result<Unit>
     val loggedIn: Flow<Boolean>
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/login/fragment/LoginFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/login/fragment/LoginFragment.kt
@@ -46,10 +46,10 @@ class LoginFragment : Fragment(R.layout.fragment_login) {
             viewModel.sigInInUiState.collectLatest {
                 if (it) {
                     if (viewModel.isFirstUser.value) {
-                        Navigation.findNavController(view).navigate(R.id.to_selectInterestFragment)
-                    }else{
                         startActivity(Intent(requireContext(), MainActivity::class.java))
                         requireActivity().finish()
+                    }else{
+                        Navigation.findNavController(view).navigate(R.id.to_selectInterestFragment)
                     }
                 }
             }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/login/vm/LoginViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/login/vm/LoginViewModel.kt
@@ -23,12 +23,6 @@ class LoginViewModel @Inject constructor(
     @Inject
     lateinit var networkErrorDelegate: NetworkErrorDelegate
 
-    init {
-        viewModelScope.launch {
-            checkIsFirstUser()
-        }
-    }
-
     val networkState get() = networkErrorDelegate.networkState
 
     private val _sigInInUiState = MutableStateFlow(false)
@@ -39,10 +33,11 @@ class LoginViewModel @Inject constructor(
 
     fun onCompleteLogIn(type: String, token: String) = viewModelScope.launch {
         authRepository.signIn(type, "Bearer $token")
+        checkIsFirstUser()
         _sigInInUiState.value = true
     }
 
-    private fun checkIsFirstUser() = viewModelScope.launch {
+    private suspend fun checkIsFirstUser(){
         memberRepository.getConcernType().onSuccess { ConcernType ->
             _isFirstUser.value = ConcernType.hasAnyTrue()
         }.onError {

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/HomeMainFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/HomeMainFragment.kt
@@ -87,7 +87,7 @@ class HomeMainFragment : Fragment(R.layout.fragment_home_main) {
         super.onViewCreated(view, savedInstanceState)
         val binding = FragmentHomeMainBinding.bind(view)
         val progressBar = binding.homeProgressbar
-      
+
         viewModel.checkAppTheme()
 
         repeatOnViewStarted {
@@ -132,33 +132,43 @@ class HomeMainFragment : Fragment(R.layout.fragment_home_main) {
                 }
 
                 launch {
-                    viewModel.userActivationState.collect{
+                    viewModel.userActivationState.collect {
                         if (it) {
                             if (isDarkTheme(resources.configuration)) showThemeGuideDialog()
                             else showThemeSettingDialog()
                         }
-                 }
+                    }
+                }
             }
-        }
 
-        settingAppTheme(binding)
-        checkLocationPermission(binding)
-        settingVPAdapter(binding)
-        getRecommendPlaceInfo(binding)
-        settingSearchBanner(binding)
+            settingAppTheme(binding)
+            checkLocationPermission(binding)
+            settingVPAdapter(binding)
+            getRecommendPlaceInfo(binding)
+            settingSearchBanner(binding)
+        }
     }
 
-    private fun settingAppTheme(binding: FragmentHomeMainBinding){
-        childFragmentManager.setFragmentResultListener("negativeButtonClick", viewLifecycleOwner) { _, _ ->
+    private fun settingAppTheme(binding: FragmentHomeMainBinding) {
+        childFragmentManager.setFragmentResultListener(
+            "negativeButtonClick",
+            viewLifecycleOwner
+        ) { _, _ ->
             viewModel.onClickThemeChangeButton(AppTheme.SYSTEM)
         }
 
-        childFragmentManager.setFragmentResultListener("positiveButtonClick", viewLifecycleOwner) { _, _ ->
+        childFragmentManager.setFragmentResultListener(
+            "positiveButtonClick",
+            viewLifecycleOwner
+        ) { _, _ ->
             viewModel.onClickThemeChangeButton(AppTheme.HIGH_CONTRAST)
             startActivity(Intent.makeRestartActivityTask(activity?.intent?.component))
         }
 
-        childFragmentManager.setFragmentResultListener("completeButtonClick", viewLifecycleOwner) { _, _ ->
+        childFragmentManager.setFragmentResultListener(
+            "completeButtonClick",
+            viewLifecycleOwner
+        ) { _, _ ->
             viewModel.onClickThemeChangeButton(AppTheme.SYSTEM)
         }
 
@@ -216,7 +226,11 @@ class HomeMainFragment : Fragment(R.layout.fragment_home_main) {
             .build()
 
         binding.homeSearchBannerIv.setOnClickListener {
-            findNavController().navigate(R.id.action_homeMainFragment_to_searchPlaceMainFragment, null, navOptions)
+            findNavController().navigate(
+                R.id.action_homeMainFragment_to_searchPlaceMainFragment,
+                null,
+                navOptions
+            )
         }
     }
 
@@ -249,10 +263,12 @@ class HomeMainFragment : Fragment(R.layout.fragment_home_main) {
                 startActivity(intent)
             })
         binding.homeRecommendRv.adapter = homeRecommendRVAdapter
-        binding.homeRecommendRv.layoutManager = LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
+        binding.homeRecommendRv.layoutManager =
+            LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
 
         val itemCount = recommendPlaceList.size
-        val customPageIndicator = CustomPageIndicator(requireActivity(), binding.homeRecommendRvIndicator, itemCount)
+        val customPageIndicator =
+            CustomPageIndicator(requireActivity(), binding.homeRecommendRvIndicator, itemCount)
 
         if (snapHelper == null) {
             snapHelper = LinearSnapHelper()
@@ -290,7 +306,8 @@ class HomeMainFragment : Fragment(R.layout.fragment_home_main) {
 
                     // 좌우 이동 조정 - 중앙에 가까운 아이템이 앞으로 나오는 효과
                     val translationXFactor = 0.25f * distanceFromCenter / centerX
-                    child.translationX = (if (childCenterX < centerX) translationXFactor else -translationXFactor) * child.width
+                    child.translationX =
+                        (if (childCenterX < centerX) translationXFactor else -translationXFactor) * child.width
 
                     if (distanceFromCenter < recyclerView.width / 2) {
                         itemBinding.touristRecommendDark.visibility = View.GONE
@@ -388,7 +405,7 @@ class HomeMainFragment : Fragment(R.layout.fragment_home_main) {
                     val geocoder = Geocoder(requireContext(), Locale.getDefault())
                     Log.d("dasdascas", "onLocationResult 호출")
 
-                    for(i in 1..3) {
+                    for (i in 1..3) {
                         try {
                             val addresses = geocoder.getFromLocation(
                                 location.latitude, location.longitude, 1

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/MyInfoMainFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/MyInfoMainFragment.kt
@@ -2,6 +2,7 @@ package kr.tekit.lion.presentation.main.fragment
 
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
@@ -9,7 +10,6 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import com.bumptech.glide.Glide
 import com.bumptech.glide.load.engine.DiskCacheStrategy
-import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -48,8 +48,6 @@ class MyInfoMainFragment : Fragment(R.layout.fragment_my_info_main) {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val binding = FragmentMyInfoMainBinding.bind(view)
-        startShimmer(binding)
-
         val isTalkbackEnabled = requireContext().isTallBackEnabled()
         val textToAnnounce = StringBuilder()
 
@@ -154,7 +152,11 @@ class MyInfoMainFragment : Fragment(R.layout.fragment_my_info_main) {
                     binding.errorContainer.visibility = View.GONE
                     binding.progressBar.visibility = View.GONE
                 }
-                is NetworkState.Error -> showErrorPage(binding, it.msg)
+                is NetworkState.Error -> {
+                    stopShimmer(binding)
+                    binding.progressBar.visibility = View.GONE
+                    showErrorPage(binding, it.msg)
+                }
             }
         }
     }
@@ -265,12 +267,15 @@ class MyInfoMainFragment : Fragment(R.layout.fragment_my_info_main) {
                 logout()
             }
             dialog.isCancelable = false
-            dialog.show(requireActivity().supportFragmentManager, "MyPageDialog")
+            dialog.show(childFragmentManager, "MyPageDialog")
         }
     }
 
     private fun logout() {
-        Snackbar.make(requireView(), "로그아웃", Snackbar.LENGTH_SHORT).show()
+        viewModel.logout{
+            startActivity(Intent(requireActivity(), LoginActivity::class.java).setFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
+            requireActivity().finish()
+        }
     }
 
     companion object {

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/vm/myinfo/MyInfoMainViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/vm/myinfo/MyInfoMainViewModel.kt
@@ -3,7 +3,6 @@ package kr.tekit.lion.presentation.main.vm.myinfo
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -11,10 +10,9 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
-import kr.tekit.lion.domain.model.MyDefaultInfo
 import kr.tekit.lion.domain.exception.onError
 import kr.tekit.lion.domain.exception.onSuccess
+import kr.tekit.lion.domain.model.MyDefaultInfo
 import kr.tekit.lion.domain.repository.AuthRepository
 import kr.tekit.lion.domain.repository.MemberRepository
 import kr.tekit.lion.presentation.delegate.NetworkErrorDelegate
@@ -66,5 +64,10 @@ class MyInfoMainViewModel @Inject constructor(
         }.onError {
             networkErrorDelegate.handleNetworkError(it)
         }
+    }
+
+    fun logout(onSuccess: () -> Unit) = viewModelScope.launch{
+        authRepository.logout()
+        onSuccess()
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #149

## 📝작업 내용

- 로그아웃 API 연결 완료
- 최초 사용 유저 판별 후 로그인 -> 관심유형 선택으로 이동시켜야 하는데
  로그인 되지 않은 상태(액세스 토큰이 없는 상태)에서 관심 유형 API를 불러와 에러가 발생해
  로그인 후 토큰을 발급받아 판별하도록 수정했습니다.

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)

[Screen_recording_20240910_165447.webm](https://github.com/user-attachments/assets/dee4b5c7-e1d0-49a0-b5d7-75a29204e948)


## 💬리뷰 요구사항(선택)

