### PR TITLE
[#145] 여행 일정 수정(여행지 검색 화면 및 등록 화면) 프로그래스바 및 에러처리

### DIFF
--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/FormSearchFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/FormSearchFragment.kt
@@ -54,8 +54,6 @@ class FormSearchFragment : Fragment(R.layout.fragment_form_search) {
 
         val binding = FragmentFormSearchBinding.bind(view)
 
-//        viewModel.getBookmarkedPlaceList()
-
         initProgressBar(binding)
         initBookmarkList()
         initToolbar(binding)

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/ModifyScheduleConfirmFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/ModifyScheduleConfirmFragment.kt
@@ -7,7 +7,6 @@ import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kr.tekit.lion.domain.model.scheduleform.DailySchedule
 import kr.tekit.lion.presentation.R
@@ -36,6 +35,9 @@ class ModifyScheduleConfirmFragment : Fragment(R.layout.fragment_modify_schedule
     }
 
     private fun settingProgressBarVisibility(binding: FragmentModifyScheduleConfirmBinding) {
+        // NetworkState의 기본값이 Loading 이기 때문에, ProgressBar가 보이지 않도록 Success로 바꿔준다
+        viewModel.resetNetworkState()
+
         with(binding) {
             lifecycleScope.launch {
                 viewModel.networkState.collectLatest { state ->

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/ModifyScheduleConfirmFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/ModifyScheduleConfirmFragment.kt
@@ -4,11 +4,15 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 import kr.tekit.lion.domain.model.scheduleform.DailySchedule
 import kr.tekit.lion.presentation.R
 import kr.tekit.lion.presentation.databinding.FragmentModifyScheduleConfirmBinding
+import kr.tekit.lion.presentation.delegate.NetworkState
 import kr.tekit.lion.presentation.ext.showSnackbar
 import kr.tekit.lion.presentation.schedule.ResultCode
 import kr.tekit.lion.presentation.scheduleform.FormDateFormat
@@ -25,8 +29,32 @@ class ModifyScheduleConfirmFragment : Fragment(R.layout.fragment_modify_schedule
 
         val binding = FragmentModifyScheduleConfirmBinding.bind(view)
 
+        settingProgressBarVisibility(binding)
+
         initToolbar(binding)
         initView(binding)
+    }
+
+    private fun settingProgressBarVisibility(binding: FragmentModifyScheduleConfirmBinding) {
+        with(binding) {
+            lifecycleScope.launch {
+                viewModel.networkState.collectLatest { state ->
+                    when(state){
+                        is NetworkState.Loading -> {
+                            progressBarModifyConfirm.visibility = View.VISIBLE
+                        }
+                        is NetworkState.Success -> {
+                            progressBarModifyConfirm.visibility = View.GONE
+                        }
+                        is NetworkState.Error -> {
+                            progressBarModifyConfirm.visibility = View.GONE
+                            buttonModifyFormSubmit.showSnackbar(state.msg)
+                        }
+
+                    }
+                }
+            }
+        }
     }
 
     private fun initToolbar(binding: FragmentModifyScheduleConfirmBinding) {

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/ModifyScheduleConfirmFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/ModifyScheduleConfirmFragment.kt
@@ -40,7 +40,7 @@ class ModifyScheduleConfirmFragment : Fragment(R.layout.fragment_modify_schedule
 
         with(binding) {
             lifecycleScope.launch {
-                viewModel.networkState.collectLatest { state ->
+                viewModel.networkState.collect { state ->
                     when(state){
                         is NetworkState.Loading -> {
                             progressBarModifyConfirm.visibility = View.VISIBLE
@@ -50,7 +50,8 @@ class ModifyScheduleConfirmFragment : Fragment(R.layout.fragment_modify_schedule
                         }
                         is NetworkState.Error -> {
                             progressBarModifyConfirm.visibility = View.GONE
-                            buttonModifyFormSubmit.showSnackbar(state.msg)
+                            val errorMsg = state.msg.replace("\n ".toRegex(), "\n")
+                            buttonModifyFormSubmit.showSnackbar(errorMsg)
                         }
 
                     }
@@ -95,8 +96,6 @@ class ModifyScheduleConfirmFragment : Fragment(R.layout.fragment_modify_schedule
 
                 requireActivity().setResult(ResultCode.RESULT_SCHEDULE_EDIT)
                 requireActivity().finish()
-            } else {
-                view.showSnackbar("다시 시도해 주세요")
             }
         }
     }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/ModifySearchFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/ModifySearchFragment.kt
@@ -49,10 +49,16 @@ class ModifySearchFragment : Fragment(R.layout.fragment_form_search) {
 
         val binding = FragmentFormSearchBinding.bind(view)
 
+        initBookmarkList()
+
         initToolbar(binding)
         settingBookmarkRV(binding, schedulePosition)
         settingSearchResultRV(binding)
         settingPlaceSearchView(binding)
+    }
+
+    private fun initBookmarkList(){
+        viewModel.initBookmarkList()
     }
 
     private fun initToolbar(binding: FragmentFormSearchBinding){

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/ModifySearchFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/ModifySearchFragment.kt
@@ -6,6 +6,7 @@ import android.view.KeyEvent
 import android.view.View
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.google.android.flexbox.AlignItems
@@ -14,8 +15,11 @@ import com.google.android.flexbox.FlexWrap
 import com.google.android.flexbox.FlexboxLayoutManager
 import com.google.android.flexbox.JustifyContent
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
 import kr.tekit.lion.presentation.R
 import kr.tekit.lion.presentation.databinding.FragmentFormSearchBinding
+import kr.tekit.lion.presentation.delegate.NetworkState
 import kr.tekit.lion.presentation.ext.addOnScrollEndListener
 import kr.tekit.lion.presentation.ext.showSnackbar
 import kr.tekit.lion.presentation.home.DetailActivity
@@ -49,6 +53,7 @@ class ModifySearchFragment : Fragment(R.layout.fragment_form_search) {
 
         val binding = FragmentFormSearchBinding.bind(view)
 
+        settingProgressBarVisibility(binding)
         initBookmarkList()
 
         initToolbar(binding)
@@ -59,6 +64,54 @@ class ModifySearchFragment : Fragment(R.layout.fragment_form_search) {
 
     private fun initBookmarkList(){
         viewModel.initBookmarkList()
+    }
+
+    private fun settingProgressBarVisibility(binding: FragmentFormSearchBinding){
+        with(binding) {
+            lifecycleScope.launch {
+                viewModel.networkState.collectLatest { state ->
+                    val searchViewVisibility = searchViewFsResult.isShowing
+
+                    when(state) {
+                        is NetworkState.Loading -> {
+                            if(searchViewVisibility){
+                                textFsResultError.visibility = View.GONE
+                                progressBarFsResult.visibility = View.VISIBLE
+                            }else{
+                                progressBarFsBookmark.visibility = View.VISIBLE
+                            }
+                        }
+                        is NetworkState.Success -> {
+                            if(searchViewVisibility){
+                                // 이전에 오류가 난 경우를 대비하여 에러메시지도 숨김처리
+                                textFsResultError.visibility = View.GONE
+                                progressBarFsResult.visibility = View.GONE
+                            }else{
+                                progressBarFsBookmark.visibility = View.GONE
+                                recyclerViewFsBookmark.visibility = View.VISIBLE
+                            }
+                        }
+                        is NetworkState.Error -> {
+                            if(searchViewVisibility){
+                                progressBarFsResult.visibility = View.GONE
+                                recyclerViewFsResult.visibility = View.GONE
+                                textFsResultError.apply {
+                                    text = state.msg
+                                    visibility = View.VISIBLE
+                                }
+                            }else{
+                                progressBarFsBookmark.visibility = View.GONE
+                                recyclerViewFsBookmark.visibility = View.GONE
+                                textFsBookmarkError.apply {
+                                    text = state.msg
+                                    visibility = View.VISIBLE
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 
     private fun initToolbar(binding: FragmentFormSearchBinding){

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/vm/ModifyScheduleFormViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/vm/ModifyScheduleFormViewModel.kt
@@ -121,8 +121,12 @@ class ModifyScheduleFormViewModel @Inject constructor(
 
     private fun getBookmarkedPlaceList() {
         viewModelScope.launch {
+            networkErrorDelegate.handleNetworkLoading()
+
             bookmarkRepository.getPlaceBookmarkList().onSuccess {
                 _bookmarkedPlaces.postValue(it)
+
+                networkErrorDelegate.handleNetworkSuccess()
             }.onError {
                 networkErrorDelegate.handleNetworkError(it)
             }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/vm/ModifyScheduleFormViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/vm/ModifyScheduleFormViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import kr.tekit.lion.domain.exception.onError
 import kr.tekit.lion.domain.exception.onSuccess
@@ -21,6 +22,7 @@ import kr.tekit.lion.domain.repository.BookmarkRepository
 import kr.tekit.lion.domain.repository.PlaceRepository
 import kr.tekit.lion.domain.repository.PlanRepository
 import kr.tekit.lion.presentation.delegate.NetworkErrorDelegate
+import kr.tekit.lion.presentation.delegate.NetworkState
 import kr.tekit.lion.presentation.ext.addDays
 import kr.tekit.lion.presentation.ext.calculateDaysUntilEndDate
 import kr.tekit.lion.presentation.ext.convertStringToDate
@@ -41,6 +43,8 @@ class ModifyScheduleFormViewModel @Inject constructor(
 
     @Inject
     lateinit var networkErrorDelegate: NetworkErrorDelegate
+
+    val networkState: StateFlow<NetworkState> get() = networkErrorDelegate.networkState
 
     // 수정 전 일정 정보
     private val _originalSchedule = MutableLiveData<OriginalScheduleInfo>()
@@ -80,10 +84,6 @@ class ModifyScheduleFormViewModel @Inject constructor(
 
     val searchResultsWithNum: LiveData<List<PlaceSearchInfoList>> get() = _searchResultsWithNum
 
-    init {
-        getBookmarkedPlaceList()
-    }
-
     fun setTitle(title: String?) {
         _title.value = title
     }
@@ -110,6 +110,13 @@ class ModifyScheduleFormViewModel @Inject constructor(
 
     fun setKeyword(keyword: String) {
         _keyword.value = keyword
+    }
+
+    fun initBookmarkList(){
+        val bookmark = _bookmarkedPlaces.value
+        if(bookmark == null) {
+            getBookmarkedPlaceList()
+        }
     }
 
     private fun getBookmarkedPlaceList() {

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/vm/ModifyScheduleFormViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/vm/ModifyScheduleFormViewModel.kt
@@ -385,9 +385,14 @@ class ModifyScheduleFormViewModel @Inject constructor(
             var requestFlag = false
 
             viewModelScope.launch {
+                networkErrorDelegate.handleNetworkLoading()
+
                 val success = try {
                     planRepository.modifySchedule(planId, revisedPlan).onSuccess {
                         requestFlag = true
+
+                        networkErrorDelegate.handleNetworkSuccess()
+
                     }.onError {
                         networkErrorDelegate.handleNetworkError(it)
                     }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/vm/ModifyScheduleFormViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/vm/ModifyScheduleFormViewModel.kt
@@ -112,6 +112,10 @@ class ModifyScheduleFormViewModel @Inject constructor(
         _keyword.value = keyword
     }
 
+    fun resetNetworkState(){
+        networkErrorDelegate.handleNetworkSuccess()
+    }
+
     fun initBookmarkList(){
         val bookmark = _bookmarkedPlaces.value
         if(bookmark == null) {
@@ -249,6 +253,8 @@ class ModifyScheduleFormViewModel @Inject constructor(
 
         if (keyword != null) {
             viewModelScope.launch {
+                networkErrorDelegate.handleNetworkLoading()
+
                 planRepository.getPlaceSearchResult(keyword, page + 1)
                     .onSuccess {
                         if (isNewRequest) {
@@ -259,6 +265,8 @@ class ModifyScheduleFormViewModel @Inject constructor(
                             val updatedResult = it.copy(placeInfoList = newList)
                             _placeSearchResult.value = updatedResult
                         }
+
+                        networkErrorDelegate.handleNetworkSuccess()
                     }.onError {
                         networkErrorDelegate.handleNetworkError(it)
                     }

--- a/DaOnGil/presentation/src/main/res/layout/fragment_modify_schedule_confirm.xml
+++ b/DaOnGil/presentation/src/main/res/layout/fragment_modify_schedule_confirm.xml
@@ -1,113 +1,143 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/navi_background"
-    android:fillViewport="true"
-    tools:context=".scheduleform.fragment.ModifyScheduleConfirmFragment" >
+    tools:context=".scheduleform.fragment.ModifyScheduleConfirmFragment">
 
-    <LinearLayout
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar_modify_confirm_form"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical">
-
-        <com.google.android.material.appbar.MaterialToolbar
-            android:id="@+id/toolbar_modify_confirm_form"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:background="@color/navi_background"
-            android:minHeight="?attr/actionBarSize"
-            app:navigationIcon="@drawable/back_icon">
-
-            <TextView
-                style="@style/Theme.Toolbar.Title"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/modify_schedule" />
-        </com.google.android.material.appbar.MaterialToolbar>
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-
-            <View
-                android:layout_width="wrap_content"
-                android:layout_height="4dp"
-                android:layout_weight="1"
-                android:background="@color/primary" />
-
-            <View
-                android:layout_width="wrap_content"
-                android:layout_height="4dp"
-                android:layout_marginHorizontal="4dp"
-                android:layout_weight="1"
-                android:background="@color/primary" />
-
-            <View
-                android:layout_width="wrap_content"
-                android:layout_height="4dp"
-                android:layout_weight="1"
-                android:background="@color/primary" />
-        </LinearLayout>
+        android:background="@color/navi_background"
+        android:minHeight="?attr/actionBarSize"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navigationIcon="@drawable/back_icon">
 
         <TextView
+            style="@style/Theme.Toolbar.Title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/margin_basic"
-            android:layout_marginTop="45dp"
-            android:fontFamily="@font/pretendard_semibold"
-            android:text="@string/text_guide_confirm"
-            android:textSize="24dp" />
+            android:text="@string/modify_schedule" />
+    </com.google.android.material.appbar.MaterialToolbar>
+
+    <LinearLayout
+        android:id="@+id/layout_modify_confirm_step"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/toolbar_modify_confirm_form">
+
+        <View
+            android:layout_width="wrap_content"
+            android:layout_height="4dp"
+            android:layout_weight="1"
+            android:background="@color/primary" />
+
+        <View
+            android:layout_width="wrap_content"
+            android:layout_height="4dp"
+            android:layout_marginHorizontal="4dp"
+            android:layout_weight="1"
+            android:background="@color/primary" />
+
+        <View
+            android:layout_width="wrap_content"
+            android:layout_height="4dp"
+            android:layout_weight="1"
+            android:background="@color/primary" />
+    </LinearLayout>
+
+    <androidx.core.widget.NestedScrollView
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:fillViewport="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/layout_modify_confirm_step">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/margin_basic"
-            android:layout_marginTop="@dimen/margin_big3"
-            android:layout_marginBottom="12dp"
-            android:orientation="horizontal">
+            android:orientation="vertical">
 
             <TextView
-                android:id="@+id/text_mcf_title"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_basic"
+                android:layout_marginTop="45dp"
+                android:fontFamily="@font/pretendard_semibold"
+                android:text="@string/text_guide_confirm"
+                android:textSize="24dp" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginHorizontal="@dimen/margin_basic"
+                android:layout_marginTop="@dimen/margin_big3"
+                android:layout_marginBottom="12dp"
+                android:orientation="horizontal">
+
+                <TextView
+                    android:id="@+id/text_mcf_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/pretendard_bold"
+                    tools:text="@string/text_selected_title" />
+
+                <TextView
+                    android:id="@+id/text_mcf_date"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/pretendard_regular"
+                    tools:text="@string/text_selected_period" />
+            </LinearLayout>
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recycler_view_mcf"
+                android:layout_width="match_parent"
+                android:layout_height="0dp"
+                android:layout_marginTop="30dp"
+                android:layout_weight="1"
+                android:nestedScrollingEnabled="false"
+                android:overScrollMode="never"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+
+            <Button
+                android:id="@+id/button_modify_form_submit"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="@dimen/margin_basic"
+                android:layout_marginTop="@dimen/margin_big1"
+                android:layout_marginEnd="@dimen/margin_basic"
+                android:layout_marginBottom="@dimen/margin_basic"
+                android:background="@drawable/background_radius_10"
                 android:fontFamily="@font/pretendard_bold"
-                tools:text="@string/text_selected_title" />
+                android:text="@string/text_save_schedule_review"
+                android:textSize="@dimen/font_big2" />
 
-            <TextView
-                android:id="@+id/text_mcf_date"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:fontFamily="@font/pretendard_regular"
-                tools:text="@string/text_selected_period" />
         </LinearLayout>
+    </androidx.core.widget.NestedScrollView>
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recycler_view_mcf"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_marginTop="30dp"
-            android:layout_weight="1"
-            android:nestedScrollingEnabled="false"
-            android:overScrollMode="never"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+    <ProgressBar
+        android:id="@+id/progressBar_modify_confirm"
+        android:layout_width="150dp"
+        android:layout_height="150dp"
+        android:layout_gravity="center"
+        android:layout_weight="1"
+        android:foregroundGravity="center"
+        android:indeterminateDrawable="@drawable/rotate_progress_bar"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-        <Button
-            android:id="@+id/button_modify_form_submit"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/margin_basic"
-            android:layout_marginTop="@dimen/margin_big1"
-            android:layout_marginEnd="@dimen/margin_basic"
-            android:layout_marginBottom="@dimen/margin_basic"
-            android:background="@drawable/background_radius_10"
-            android:fontFamily="@font/pretendard_bold"
-            android:text="@string/text_save_schedule_review"
-            android:textSize="@dimen/font_big2" />
-        
-    </LinearLayout>
-    
-</androidx.core.widget.NestedScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #145

## 📝작업 내용

- 여행 일정 수정 화면의 여행지 검색 화면에서 프로그래스바 및 네트워크 에러 처리했습니다.
- 수정된 일정 등록 API 호출 시에도 프로그래스바 나오도록 수정하고, 에러가 발생할 땐 snackBar로 메시지만 출력하게 했습니다. (혹시 네트워크 복구되거나, 서버에 이상 없을 때 수정된 내용을 등록할 수 있도록)

## PR 발행 전 체크 리스트

- [ ] 발행자 확인
- [ ] 프로젝트 설정 확인
- [ ] 라벨 확인

## 스크린샷 (선택)

https://github.com/user-attachments/assets/99141c86-98a4-47a5-978d-d8e2fbd10db4

![Screenshot_1725956444](https://github.com/user-attachments/assets/fd40b28b-36a9-4c79-8553-8c89c0896829)



## 💬리뷰 요구사항(선택)
- 스크린샷 영상에는 프로그래스바가 recyclerView 뒤에 있어서 조금 가려져있는데, 이 부분 확인하고 수정해서 머지했습니다. (사진으로 첨부했습니다)

- 첨부한 스크린샷 영상처럼 수정된 일정 등록 API 호출 시에도 프로그래스바 나오도록 수정하고, 에러가 발생할 땐 snackBar로 메시지만 출력하게 했습니다.  (혹시 네트워크 복구되거나, 서버에 이상 없을 때 수정된 내용을 등록할 수 있도록)
- 만약 에러가 발생했을 때, 모든 뷰를 가리면 [일정 등록] 버튼을 다시 누를 수 없을 것 같아서 스낵바만 보여주게 설정했는데, 이 부분은 어떤 방식으로 처리하면 좋을까요? 
