### PR TITLE
[#161] 관광지 리뷰 신고하기 연결

### DIFF
--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/DetailActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/DetailActivity.kt
@@ -63,7 +63,7 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
         binding.detailDisabilityInfoRv.layoutManager = LinearLayoutManager(applicationContext)
     }
 
-    private fun settingReviewRVAdapter(reviewList: List<Review>) {
+    private fun settingReviewRVAdapter(reviewList: List<Review>, loginState: Boolean) {
         if (reviewList.isEmpty()) {
             binding.detailReviewRv.visibility = View.GONE
             binding.detailNoReviewTv.visibility = View.VISIBLE
@@ -72,7 +72,7 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
             binding.detailReviewRv.visibility = View.VISIBLE
             binding.detailNoReviewTv.visibility = View.GONE
 
-            val detailReviewRVAdapter = DetailReviewRVAdapter(reviewList)
+            val detailReviewRVAdapter = DetailReviewRVAdapter(reviewList, loginState)
             binding.detailReviewRv.adapter = detailReviewRVAdapter
             binding.detailReviewRv.layoutManager = LinearLayoutManager(applicationContext)
         }
@@ -139,10 +139,11 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
         longitude: Double,
         latitude: Double,
         category: String,
-        subDisability: List<SubDisability>?
+        subDisability: List<SubDisability>?,
+        loginState: Boolean
     ) {
         reviewList?.let {
-            settingReviewRVAdapter(it)
+            settingReviewRVAdapter(it, loginState)
 
             val myReview = it.filter { review -> review.myReview }
 
@@ -214,7 +215,8 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
                 detailPlaceInfo.longitude.toDouble(),
                 detailPlaceInfo.latitude.toDouble(),
                 detailPlaceInfo.category,
-                detailPlaceInfo.subDisability
+                detailPlaceInfo.subDisability,
+                true
             )
 
             updateBookmarkState(detailPlaceInfo.isMark)
@@ -264,7 +266,8 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
                 detailPlaceInfoGuest.longitude.toDouble(),
                 detailPlaceInfoGuest.latitude.toDouble(),
                 detailPlaceInfoGuest.category,
-                detailPlaceInfoGuest.subDisability
+                detailPlaceInfoGuest.subDisability,
+                false
             )
             binding.detailBookmarkBtn.visibility = View.GONE
             binding.detailWriteReviewBtn.visibility = View.GONE

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/ReviewListActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/ReviewListActivity.kt
@@ -60,18 +60,8 @@ class ReviewListActivity : AppCompatActivity() {
         }
     }
 
-    private fun settingReviewListRVAdapter(reviewList: List<PlaceReview>) {
-        val reviewListRVAdapter = ReviewListRVAdapter(reviewList) {
-            val dialog = ConfirmDialog(
-                "신고하기",
-                "해당 댓글을 신고하시겠습니까?",
-                "신고하기"
-            ) {
-                // 신고하기 api 연결
-            }
-            dialog.isCancelable = false
-            dialog.show(supportFragmentManager, "PlaceReviewListDialog")
-        }
+    private fun settingReviewListRVAdapter(reviewList: List<PlaceReview>, loginState: Boolean) {
+        val reviewListRVAdapter = ReviewListRVAdapter(reviewList, loginState)
 
         binding.reviewListRv.adapter = reviewListRVAdapter
         binding.reviewListRv.layoutManager = LinearLayoutManager(applicationContext)
@@ -96,7 +86,7 @@ class ReviewListActivity : AppCompatActivity() {
                 .error(R.drawable.empty_view)
                 .into(binding.reviewListThumbnailIv)
 
-            settingReviewListRVAdapter(placeReviewInfo.placeReviewList)
+            settingReviewListRVAdapter(placeReviewInfo.placeReviewList, true)
         }
     }
 
@@ -119,7 +109,7 @@ class ReviewListActivity : AppCompatActivity() {
                 .error(R.drawable.empty_view)
                 .into(binding.reviewListThumbnailIv)
 
-            settingReviewListRVAdapter(placeReviewInfo.placeReviewList)
+            settingReviewListRVAdapter(placeReviewInfo.placeReviewList, false)
         }
     }
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/adapter/DetailReviewRVAdapter.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/adapter/DetailReviewRVAdapter.kt
@@ -1,5 +1,6 @@
 package kr.tekit.lion.presentation.home.adapter
 
+import android.content.Intent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -9,7 +10,7 @@ import com.bumptech.glide.Glide
 import kr.tekit.lion.domain.model.detailplace.Review
 import kr.tekit.lion.presentation.R
 import kr.tekit.lion.presentation.databinding.ItemDetailReviewBigBinding
-import kr.tekit.lion.presentation.home.DetailActivity
+import kr.tekit.lion.presentation.report.ReportActivity
 
 class DetailReviewRVAdapter(
     private val reviewList: List<Review>
@@ -47,10 +48,9 @@ class DetailReviewRVAdapter(
                 if (reviewData.reviewImgs != null) {
                     itemDetailReviewBigRv.visibility = View.VISIBLE
 
-                    val reviewImageRVAdapter =
-                        ReviewImageRVAdapter(reviewData.reviewImgs!!)
-                    binding.itemDetailReviewBigRv.adapter = reviewImageRVAdapter
-                    binding.itemDetailReviewBigRv.layoutManager =
+                    val reviewImageRVAdapter = ReviewImageRVAdapter(reviewData.reviewImgs!!)
+                    itemDetailReviewBigRv.adapter = reviewImageRVAdapter
+                    itemDetailReviewBigRv.layoutManager =
                         LinearLayoutManager(
                             binding.root.context,
                             LinearLayoutManager.HORIZONTAL,
@@ -65,6 +65,17 @@ class DetailReviewRVAdapter(
                 } else {
                     itemDetailReviewBigReportBtn.visibility = View.VISIBLE
                 }
+
+                itemDetailReviewBigReportBtn.setOnClickListener {
+                    val context = binding.root.context
+
+                    val intent = Intent(context, ReportActivity::class.java).apply {
+                        putExtra("reviewType", "PlaceReview")
+                        putExtra("reviewId", reviewData.reviewId)
+                    }
+                    context.startActivity(intent)
+                }
+
             }
         }
     }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/adapter/DetailReviewRVAdapter.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/adapter/DetailReviewRVAdapter.kt
@@ -4,16 +4,20 @@ import android.content.Intent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.FragmentActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import kr.tekit.lion.domain.model.detailplace.Review
 import kr.tekit.lion.presentation.R
 import kr.tekit.lion.presentation.databinding.ItemDetailReviewBigBinding
+import kr.tekit.lion.presentation.login.LoginActivity
+import kr.tekit.lion.presentation.main.dialog.ConfirmDialog
 import kr.tekit.lion.presentation.report.ReportActivity
 
 class DetailReviewRVAdapter(
-    private val reviewList: List<Review>
+    private val reviewList: List<Review>,
+    private val loginState: Boolean
 ) : RecyclerView.Adapter<DetailReviewRVAdapter.DetailReviewViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): DetailReviewViewHolder {
@@ -21,7 +25,7 @@ class DetailReviewRVAdapter(
             LayoutInflater.from(parent.context), parent, false
         )
 
-        return DetailReviewViewHolder(binding)
+        return DetailReviewViewHolder(binding, loginState)
     }
 
     override fun getItemCount(): Int = reviewList.size
@@ -31,7 +35,8 @@ class DetailReviewRVAdapter(
     }
 
     class DetailReviewViewHolder(
-        private val binding: ItemDetailReviewBigBinding
+        private val binding: ItemDetailReviewBigBinding,
+        private val loginState: Boolean
     ) : RecyclerView.ViewHolder(binding.root) {
         fun bind(reviewData: Review) {
             with(binding) {
@@ -67,15 +72,35 @@ class DetailReviewRVAdapter(
                 }
 
                 itemDetailReviewBigReportBtn.setOnClickListener {
-                    val context = binding.root.context
+                    if (loginState) {
+                        val context = binding.root.context
 
-                    val intent = Intent(context, ReportActivity::class.java).apply {
-                        putExtra("reviewType", "PlaceReview")
-                        putExtra("reviewId", reviewData.reviewId)
+                        val intent = Intent(context, ReportActivity::class.java).apply {
+                            putExtra("reviewType", "PlaceReview")
+                            putExtra("reviewId", reviewData.reviewId)
+                        }
+                        context.startActivity(intent)
+                    } else {
+                        displayLoginDialog("후기를 신고하고 싶다면\n 로그인을 진행해주세요", binding)
                     }
-                    context.startActivity(intent)
                 }
+            }
+        }
 
+        private fun displayLoginDialog(subtitle: String, binding: ItemDetailReviewBigBinding) {
+            val context = binding.root.context
+            val dialog = ConfirmDialog(
+                "로그인이 필요해요!",
+                subtitle,
+                "로그인하기",
+            ) {
+                val intent = Intent(context, LoginActivity::class.java)
+                context.startActivity(intent)
+            }
+
+            if (context is FragmentActivity) {
+                dialog.isCancelable = true
+                dialog.show(context.supportFragmentManager, "ScheduleLoginDialog")
             }
         }
     }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/adapter/ReviewListRVAdapter.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/adapter/ReviewListRVAdapter.kt
@@ -1,15 +1,16 @@
 package kr.tekit.lion.presentation.home.adapter
 
+import android.content.Intent
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.bumptech.glide.Glide
 import kr.tekit.lion.domain.model.placereviewlist.PlaceReview
 import kr.tekit.lion.presentation.R
 import kr.tekit.lion.presentation.databinding.ItemDetailReviewBigBinding
+import kr.tekit.lion.presentation.report.ReportActivity
 
 class ReviewListRVAdapter(
     private val reviewList: List<PlaceReview>,
@@ -66,6 +67,15 @@ class ReviewListRVAdapter(
                 binding.itemDetailReviewBigReportBtn.visibility = View.VISIBLE
             }
 
+            binding.itemDetailReviewBigReportBtn.setOnClickListener {
+                val context = binding.root.context
+
+                val intent = Intent(context, ReportActivity::class.java).apply {
+                    putExtra("reviewType", "PlaceReview")
+                    putExtra("reviewId", review.reviewId.toLong())
+                }
+                context.startActivity(intent)
+            }
         }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #161 

## 📝작업 내용

- 관광지 상세보기 하단 리뷰 신고하기 화면 연결
- 관광지 리뷰 전체보기 리뷰 신고하기 화면 연결
- 각 신고하기에서 로그인/게스트 별 분기 처리
  - 로그인ver -> 신고하기 화면으로 이동
  - 게스트ver -> 로그인 다이얼로그 띄우기

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
- 로그인ver

https://github.com/user-attachments/assets/dacbed8e-5cc8-45a0-84fd-940c6e08b07c


- 게스트ver

https://github.com/user-attachments/assets/a45d3ffa-10d2-41c0-80a1-d1dc682564b6


## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  - 신고하기 완료 후 토스트바 추가 하였습니다 !
