### PR TITLE
[#164] 키워드 검색화면 에러 처리

### DIFF
--- a/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/exception/HttpError.kt
+++ b/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/exception/HttpError.kt
@@ -1,37 +1,37 @@
 package kr.tekit.lion.domain.exception
 
-sealed class HttpException : NetworkError() {
+sealed class HttpError : NetworkError() {
     abstract override val title: String
     abstract override val message: String
 }
-data object BadRequestError : HttpException(){
+data object BadRequestError : HttpError(){
     override val title: String
         get() = "인증 오류가 발생했어요"
     override val message: String
         get() = "요청 내용을 확인하고 다시 시도해주세요."
 }
-data object AuthenticationError : HttpException() {
+data object AuthenticationError : HttpError() {
     override val title: String
         get() = "로그인 문제가 발생했습니다."
     override val message: String
         get() = "문제가 반복 된다면 다시 로그인해주세요."
 }
 
-data object AuthorizationError : HttpException() {
+data object AuthorizationError : HttpError() {
     override val title: String
         get() = "서비스 이용 권한에 문제가 발생했습니다."
     override val message: String
         get() = "해당 서비스에 대한 유저 권한이 없어요."
 }
 
-data object NotFoundError : HttpException() {
+data object NotFoundError : HttpError() {
     override val title: String
         get() = "해당 서비스를 찾을 수 없어요"
     override val message: String
         get() = "요청하신 페이지 또는 정보가 존재하지 않습니다."
 }
 
-data object ServerError : HttpException() {
+data object ServerError : HttpError() {
     override val title: String
         get() = "서버에 오류가 발생했어요"
     override val message: String

--- a/DaOnGil/presentation/src/main/AndroidManifest.xml
+++ b/DaOnGil/presentation/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/delegate/NetworkErrorDelegate.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/delegate/NetworkErrorDelegate.kt
@@ -7,7 +7,7 @@ import kr.tekit.lion.domain.exception.AuthenticationError
 import kr.tekit.lion.domain.exception.AuthorizationError
 import kr.tekit.lion.domain.exception.BadRequestError
 import kr.tekit.lion.domain.exception.ConnectError
-import kr.tekit.lion.domain.exception.HttpException
+import kr.tekit.lion.domain.exception.HttpError
 import kr.tekit.lion.domain.exception.NetworkError
 import kr.tekit.lion.domain.exception.NotFoundError
 import kr.tekit.lion.domain.exception.ServerError
@@ -25,7 +25,7 @@ class NetworkErrorDelegate @Inject constructor() {
             is ConnectError -> "${ConnectError.title} \n ${ConnectError.message}"
             is TimeoutError -> "${TimeoutError.title} \n ${TimeoutError.message}"
             is UnknownHostError -> "${UnknownError.title} \n ${UnknownHostError.message}"
-            is HttpException -> when (exception) {
+            is HttpError -> when (exception) {
                 is BadRequestError -> "${BadRequestError.title} \n ${BadRequestError.message}"
                 is AuthenticationError -> "${AuthenticationError.title} \n ${AuthenticationError.message}"
                 is AuthorizationError -> "${AuthorizationError.title} \n ${AuthorizationError.message}"

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/keyword/vm/KeywordSearchViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/keyword/vm/KeywordSearchViewModel.kt
@@ -6,20 +6,24 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.FlowPreview
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.debounce
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kr.tekit.lion.domain.exception.NetworkError
-import kr.tekit.lion.domain.model.search.RecentlySearchKeyword
+import kr.tekit.lion.domain.exception.TimeoutError
+import kr.tekit.lion.domain.exception.UnknownError
+import kr.tekit.lion.domain.exception.UnknownHostError
 import kr.tekit.lion.domain.model.search.RecentlySearchKeywordList
 import kr.tekit.lion.domain.model.search.findKeyword
 import kr.tekit.lion.domain.model.search.toRecentlySearchKeyword
@@ -27,12 +31,15 @@ import kr.tekit.lion.domain.repository.PlaceRepository
 import kr.tekit.lion.domain.repository.RecentlySearchKeywordRepository
 import kr.tekit.lion.presentation.delegate.NetworkErrorDelegate
 import kr.tekit.lion.presentation.keyword.model.KeywordInputState
+import kr.tekit.lion.presentation.observer.ConnectivityObserver
+import java.net.UnknownHostException
+import java.util.concurrent.TimeoutException
 import javax.inject.Inject
 
 @HiltViewModel
 class KeywordSearchViewModel @Inject constructor(
     private val placeRepository: PlaceRepository,
-    private val recentlySearchKeywordRepository: RecentlySearchKeywordRepository
+    private val recentlySearchKeywordRepository: RecentlySearchKeywordRepository,
 ) : ViewModel() {
 
     init {
@@ -43,7 +50,10 @@ class KeywordSearchViewModel @Inject constructor(
 
     @Inject
     lateinit var networkErrorDelegate: NetworkErrorDelegate
-    val networkState get() = networkErrorDelegate.networkState
+    val errorState get() = networkErrorDelegate.networkState
+
+    private val _networkStatus = MutableStateFlow(ConnectivityObserver.Status.Available)
+    val networkStatus = _networkStatus.asStateFlow()
 
     private val _recentlySearchKeyword = MutableStateFlow(RecentlySearchKeywordList(emptyList()))
     val recentlySearchKeyword = _recentlySearchKeyword.asStateFlow()
@@ -54,26 +64,36 @@ class KeywordSearchViewModel @Inject constructor(
     private val _searchState = MutableStateFlow(KeywordInputState.Initial)
     val searchState = _searchState.asStateFlow()
 
-    @OptIn(FlowPreview:: class,  ExperimentalCoroutinesApi:: class)
+    @OptIn(FlowPreview:: class, ExperimentalCoroutinesApi:: class)
     val autocompleteKeyword = keyword
         .debounce(DEBOUNCE_INTERVAL)
         .distinctUntilChanged()
         .filter { it.isNotEmpty() }
-        .flatMapLatest { keyword ->
-            if (searchState.value != KeywordInputState.Erasing) {
-                networkErrorDelegate.handleNetworkLoading()
-                placeRepository.getAutoCompleteKeyword(keyword)
+        .combine(_networkStatus){keyword, status -> keyword to status}
+        .flatMapLatest { (keyword, status) ->
+            if (status == ConnectivityObserver.Status.Available && searchState.value != KeywordInputState.Erasing) {
+                val response = placeRepository.getAutoCompleteKeyword(keyword)
+                networkErrorDelegate.handleNetworkSuccess()
+                response
             } else {
                 flow { }
             }
         }
         .flowOn(Dispatchers.IO)
-        .catch { e: Throwable ->
-            when (e) {
-                is NetworkError -> networkErrorDelegate.handleNetworkError(e)
+        .catch { e ->
+            submitThrowableState(e)
+        }.retryWhen{ cause, attempt ->
+            if (cause is TimeoutException && attempt < 3) {
+                delay(1000)
+                true
+            } else {
+                false
             }
         }
 
+    fun onChangeNetworkState(state: ConnectivityObserver.Status) {
+        _networkStatus.value = state
+    }
 
     fun inputTextChanged(keyword: String) {
         if (searchState.value != KeywordInputState.Erasing) {
@@ -106,6 +126,23 @@ class KeywordSearchViewModel @Inject constructor(
 
     fun onClickDeleteButton() = viewModelScope.launch(Dispatchers.IO) {
         recentlySearchKeywordRepository.deleteAllKeyword()
+    }
+
+    private fun submitThrowableState(e: Throwable){
+        when (e) {
+            is TimeoutException ->{
+                networkErrorDelegate.handleNetworkError(TimeoutError)
+            }
+            is UnknownHostException -> {
+                networkErrorDelegate.handleNetworkError(UnknownHostError)
+            }
+            is UnknownError -> {
+                networkErrorDelegate.handleNetworkError(UnknownError)
+            }
+            else -> {
+                networkErrorDelegate.handleNetworkError(e as NetworkError)
+            }
+        }
     }
 
     companion object {

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/observer/ConnectivityObserver.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/observer/ConnectivityObserver.kt
@@ -1,0 +1,11 @@
+package kr.tekit.lion.presentation.observer
+
+import kotlinx.coroutines.flow.Flow
+
+interface ConnectivityObserver {
+    fun getFlow(): Flow<Status>
+
+    enum class Status{
+        Available, Unavailable, Losing, Lost
+    }
+}

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/observer/NetworkConnectivityObserver.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/observer/NetworkConnectivityObserver.kt
@@ -1,0 +1,73 @@
+package kr.tekit.lion.presentation.observer
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Network
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted.Companion.WhileSubscribed
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+class NetworkConnectivityObserver(
+    context: Context
+): ConnectivityObserver {
+
+    private val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+
+    @OptIn(DelicateCoroutinesApi::class)
+    private val status: Flow<ConnectivityObserver.Status> =
+        observe().stateIn(GlobalScope, WhileSubscribed(5000), ConnectivityObserver.Status.Unavailable)
+
+    override fun getFlow(): Flow<ConnectivityObserver.Status> {
+        return status
+    }
+
+    private fun observe(): Flow<ConnectivityObserver.Status> {
+        return callbackFlow {
+            val callback = object : ConnectivityManager.NetworkCallback(){
+                override fun onAvailable(network: Network) {
+                    super.onAvailable(network)
+                    launch { send(ConnectivityObserver.Status.Available) }
+                }
+
+                override fun onLosing(network: Network, maxMsToLive: Int) {
+                    super.onLosing(network, maxMsToLive)
+                    launch { send(ConnectivityObserver.Status.Losing) }
+                }
+
+                override fun onLost(network: Network) {
+                    super.onLost(network)
+                    launch { send(ConnectivityObserver.Status.Lost) }
+                }
+
+                override fun onUnavailable(){
+                    super.onUnavailable()
+                    launch { send(ConnectivityObserver.Status.Unavailable) }
+                }
+            }
+
+            connectivityManager.registerDefaultNetworkCallback(callback)
+
+            awaitClose{
+                connectivityManager.unregisterNetworkCallback(callback)
+            }
+        }.distinctUntilChanged()
+    }
+
+    companion object{
+
+        @Volatile
+        private var INSTANCE: NetworkConnectivityObserver? = null
+
+        fun getInstance(context: Context): ConnectivityObserver{
+            return INSTANCE ?: synchronized(this){
+                INSTANCE ?: NetworkConnectivityObserver(context).also { INSTANCE = it }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

- #164 

## 📝작업 내용

- 키워드 검색 화면에서 인터넷이 끊겼다가 다시 연결되면 검색결과를 보여주도록 구현했습니다.

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
- ### 추천 검색어 네트워크 오류시

[Screen_recording_20240911_133550.webm](https://github.com/user-attachments/assets/a853a832-8687-4d99-9f70-c8f6d3f6dfcb)

- ### 검색 결과 네트워크 오류시

[Screen_recording_20240911_133701.webm](https://github.com/user-attachments/assets/a4f80032-0cf2-445a-b521-7243a3e20557)


## 💬리뷰 요구사항(선택)

사용자가 네트워크가 끊긴 상태에서 검색했다면 다시 연결했을 때 내용을 바로 보여주기 위한 로직을 구현했습니다.

우선 connectivityManager는 안드로이드에서 네트워크 연결 상태를 확인하고 관리하는 데 사용되는 클래스 입니다. 
``` val connectivityManager = context.getSystemService(  Context. CONNECTIVITY_ SERVICE)  as ConnectivityManager ```

connectivityManager의 NetworkCallback에는 네트워크 상태에 따라 특정 콜백을 수행할 수 있는 네개의 함수가 있습니다.
+ onAvailable(network:  Network)    
   네트워크 연결이 가능해졌을 때 호출 
+ onLosing(network: Network, maxMsToLive: Int)    
    네트워크 연결이 곧 끊어질 예정일 때 호출    
    maxMsToLive 매개변수는 네트워크 연결이 끊어지기까지 남은 예상 시간(밀리초)입니다.   
    이 함수 내에서 ConnectivityObserver. Status. Losing을 Flow에 보내 네트워크 연결이 곧 끊어질 예정임을 알립니다. 
+ onLost(network: Network)    
    네트워크 연결이 끊겼을 때 호출    
    이 함수 내에서 ConnectivityObserver. Status. Lost를 Flow에 보내 네트워크 연결이 끊겼음을 알립니다. 
+ onUnavailable()    
    네트워크를 사용할 수 없을 때 호출

네트워크 상태를 옵저빙하는 함수를 전체적으로 봤을 때 인터넷 상태에 따라 각각의 콜백 함수들이 호출되고 callFlow 형태로 리턴합니다. callFlow는 그냥 쉽게 생각해서 말 그대로 콜백을 플로우로 반환한다고 보시면 됩니다! 

다만 callFlow는 한번 사용된 콜백은 awaitClose를 통해 해제 해줘야 메모리 릭을 방지할 수 있습니다. 
그리고 distinctUntilChanged 은 동일한 값이 방출되는 것을 무시합니다.

``` 
private fun observe(): Flow<ConnectivityObserver.Status> {
        return callbackFlow {
            val callback = object : ConnectivityManager.NetworkCallback(){
                override fun onAvailable(network: Network) {
                    super.onAvailable(network)
                    launch { send(ConnectivityObserver.Status.Available) }
                }

                override fun onLosing(network: Network, maxMsToLive: Int) {
                    super.onLosing(network, maxMsToLive)
                    launch { send(ConnectivityObserver.Status.Losing) }
                }

                override fun onLost(network: Network) {
                    super.onLost(network)
                    launch { send(ConnectivityObserver.Status.Lost) }
                }

                override fun onUnavailable(){
                    super.onUnavailable()
                    launch { send(ConnectivityObserver.Status.Unavailable) }
                }
            }

            connectivityManager.registerDefaultNetworkCallback(callback)

            awaitClose{
                connectivityManager.unregisterNetworkCallback(callback)
            }
        }.distinctUntilChanged()
    }
```

마지막으로 이 모든 상태를 가진 status라는 프로퍼티는 Flow 즉, 콜드 스트림기 때문에 최신 값을 알 수 없고 데이터를 구독해야만 상태를 알 수 있어 stateIn 함수를 사용해 핫 스트림으로 변경해주었습니다.

``` 
private val status: Flow<ConnectivityObserver. Status>  =  
     observe().stateIn(GlobalScope,  WhileSubscribed(5000) ,  ConnectivityObserver. Status. Unavailable) 
 ```

참조
https://android-devpia.tistory.com/16

PS. PR 다쓰고 제출하려니까 갑자기 이미 생성된 PR이라면서 내용이 다 날라갔었네요... 
겁나 열심히 썼는데 멘탈이 좀 나가서 내용이 부실하거나 이상한거 있으면 말씀해주세요 .. ㅠㅠㅠㅠㅠ