### PR TITLE
[#178] 홈 위치권한 거절 시 처리

### DIFF
--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/HomeMainFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/HomeMainFragment.kt
@@ -86,6 +86,7 @@ class HomeMainFragment : Fragment(R.layout.fragment_home_main) {
         } else {
             requireContext().showPermissionSnackBar(FragmentHomeMainBinding.bind(requireView()).root)
             hideLocationRv(FragmentHomeMainBinding.bind(requireView()))
+            viewModel.getPlaceMain(DEFAULT_AREA, DEFAULT_SIGUNGU)
         }
     }
 

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/HomeMainFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/HomeMainFragment.kt
@@ -428,7 +428,8 @@ class HomeMainFragment : Fragment(R.layout.fragment_home_main) {
                             return
                         } catch (e: IOException) {
                             if (i == 4) {
-                                Log.e("HomeMainFragment", "Geocoder 위치 가져오기 실패", e)
+                                getAroundPlaceInfo(binding, DEFAULT_AREA, DEFAULT_SIGUNGU)
+                                binding.root.showSnackbar("위치를 찾을 수 없어 기본값($DEFAULT_AREA $DEFAULT_SIGUNGU)으로 설정합니다")
                             }
                         }
                         // 재시도 전 대기 시간

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/HomeMainFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/HomeMainFragment.kt
@@ -75,7 +75,7 @@ class HomeMainFragment : Fragment(R.layout.fragment_home_main) {
 
     companion object {
         const val DEFAULT_AREA = "서울특별시"
-        const val DEFAULT_SIGUNGU = "강남구"
+        const val DEFAULT_SIGUNGU = "중구"
     }
 
     private val requestPermissionLauncher = registerForActivityResult(

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/HomeMainFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/HomeMainFragment.kt
@@ -48,6 +48,7 @@ import kr.tekit.lion.presentation.databinding.ItemTouristRecommendBinding
 import kr.tekit.lion.presentation.delegate.NetworkState
 import kr.tekit.lion.presentation.ext.repeatOnViewStarted
 import kr.tekit.lion.presentation.ext.showPermissionSnackBar
+import kr.tekit.lion.presentation.ext.showSnackbar
 import kr.tekit.lion.presentation.home.DetailActivity
 import kr.tekit.lion.presentation.home.model.HomeViewPagerPage
 import kr.tekit.lion.presentation.main.adapter.HomeLocationRVAdapter
@@ -71,6 +72,11 @@ class HomeMainFragment : Fragment(R.layout.fragment_home_main) {
     private lateinit var locationCallback: LocationCallback
     private val retryDelayMillis = 5000L
     private var snapHelper: SnapHelper? = null
+
+    companion object {
+        const val DEFAULT_AREA = "서울특별시"
+        const val DEFAULT_SIGUNGU = "강남구"
+    }
 
     private val requestPermissionLauncher = registerForActivityResult(
         ActivityResultContracts.RequestPermission()
@@ -470,12 +476,19 @@ class HomeMainFragment : Fragment(R.layout.fragment_home_main) {
         binding.homeMyLocationTv.text = "위치 권한을 허용해주세요"
     }
 
+    @SuppressLint("SetTextI18n")
     private fun getAroundPlaceInfo(
         binding: FragmentHomeMainBinding,
         areaCode: String,
         sigunguCode: String
     ) {
         viewModel.getPlaceMain(areaCode, sigunguCode)
+
+        viewModel.locationMessage.observe(viewLifecycleOwner) { message ->
+            binding.root.showSnackbar(message)
+
+            binding.homeMyLocationTv.text = "$DEFAULT_AREA $DEFAULT_SIGUNGU"
+        }
 
         viewModel.aroundPlaceInfo.observe(requireActivity()) { aroundPlaceInfo ->
             if (aroundPlaceInfo.isNotEmpty()) {

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/vm/home/HomeViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/vm/home/HomeViewModel.kt
@@ -47,7 +47,7 @@ class HomeViewModel @Inject constructor(
 
     companion object {
         const val DEFAULT_AREA = "서울특별시"
-        const val DEFAULT_SIGUNGU = "강남구"
+        const val DEFAULT_SIGUNGU = "중구"
     }
 
     @Inject

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/vm/home/HomeViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/vm/home/HomeViewModel.kt
@@ -45,6 +45,11 @@ class HomeViewModel @Inject constructor(
         }
     }
 
+    companion object {
+        const val DEFAULT_AREA = "서울특별시"
+        const val DEFAULT_SIGUNGU = "강남구"
+    }
+
     @Inject
     lateinit var networkErrorDelegate: NetworkErrorDelegate
     val networkState: StateFlow<NetworkState> get() = networkErrorDelegate.networkState
@@ -60,6 +65,9 @@ class HomeViewModel @Inject constructor(
 
     private val _userActivationState = MutableSharedFlow<Boolean>()
     val userActivationState = _userActivationState.asSharedFlow()
+
+    private val _locationMessage = MutableLiveData<String>()
+    val locationMessage: LiveData<String> get() = _locationMessage
 
     fun checkAppTheme() = viewModelScope.launch{
         val appTheme = appThemeRepository.getAppTheme()
@@ -104,8 +112,14 @@ class HomeViewModel @Inject constructor(
 
     fun getPlaceMain(area: String, sigungu: String) = viewModelScope.launch(Dispatchers.IO) {
 
-      val areaCode = getAreaCode(area)
-      val sigunguCode = getSigunguCode(sigungu)
+        var areaCode = getAreaCode(area)
+        var sigunguCode = getSigunguCode(sigungu)
+
+        if (areaCode == null || sigunguCode == null) {
+            _locationMessage.postValue("위치를 찾을 수 없어 기본값($DEFAULT_AREA, $DEFAULT_SIGUNGU)으로 설정합니다.")
+            areaCode = getAreaCode(DEFAULT_AREA)
+            sigunguCode = getSigunguCode(DEFAULT_SIGUNGU)
+        }
 
         if (areaCode != null && sigunguCode != null) {
             placeRepository.getPlaceMainInfo(areaCode, sigunguCode).onSuccess {


### PR DESCRIPTION
## #️⃣연관된 이슈

- #178 

## 📝작업 내용

- 홈 위치권한 거절 시 위치 기반 추천 숨김 처리
- 현재 본인 위치를 잡지 못할 때 기본값으로 설정
- 현재 위치의 지역 코드가 데이터베이스에 존재하지 않을 때 기본값으로 설정   

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
- 홈 위치권한 거절 시 위치 기반 추천 숨김 처리
https://github.com/user-attachments/assets/fd9967c1-40e5-478f-8f03-0ea1a4272e28


- 현재 본인 위치를 잡지 못할 때 기본값으로 설정

https://github.com/user-attachments/assets/277e9639-af7f-4a87-998b-cc17468deae1


- 현재 위치의 지역 코드가 데이터베이스에 존재하지 않을 때 기본값으로 설정   
![스크린샷 2024-09-11 오후 6 11 35](https://github.com/user-attachments/assets/8235acc1-21e3-49bb-b9ad-620464a2999d)

https://github.com/user-attachments/assets/ed0964e9-6ca1-460e-99cf-bb8fec11b818


## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  - 위치 관련해서 발생했던 에러들 관련해서 처리했습니다
  - 일단 위치를 찾지 못하거나 DB에 없는 경우 기본값으로 "서울특별시 강남구"로 설정하도록 해뒀는데 다른 의견 있으시면 말씀해주세요 ~