### PR TITLE
[#166] 일정 메인화면 및 상세보기 오류 수정

### DIFF
--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/datasource/PlanDataSource.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/datasource/PlanDataSource.kt
@@ -84,7 +84,7 @@ internal class PlanDataSource @Inject constructor(
     }
 
     suspend fun getDetailScheduleInfoGuest(planId: Long): ScheduleDetailInfo {
-        return planService.getDetailScheduleInfo(planId).toDomainModel()
+        return planService.getDetailScheduleInfoGuest(planId).toDomainModel()
     }
 
     suspend fun getDetailScheduleReview(planId: Long): ScheduleDetailReview {
@@ -92,7 +92,7 @@ internal class PlanDataSource @Inject constructor(
     }
 
     suspend fun getDetailScheduleReviewGuest(planId: Long): ScheduleDetailReview {
-        return planService.getDetailScheduleReview(planId).toDomainModel()
+        return planService.getDetailScheduleReviewGuest(planId).toDomainModel()
     }
 
     suspend fun deleteMyPlanReview(reviewId: Long) {

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/ScheduleMainFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/ScheduleMainFragment.kt
@@ -3,6 +3,7 @@ package kr.tekit.lion.presentation.main.fragment
 import android.app.Activity
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.fragment.app.Fragment
@@ -56,7 +57,12 @@ class ScheduleMainFragment : Fragment(R.layout.fragment_schedule_main) {
             view?.showSnackbar("일정이 삭제되었습니다", Snackbar.LENGTH_LONG)
             viewModel.getScheduleMainLists()
         } else {
-            viewModel.getScheduleMainLists()
+            if(isUser){
+                viewModel.getScheduleMainLists()
+            } else {
+                viewModel.getOpenPlanList()
+            }
+
         }
     }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #166 

## 📝작업 내용

- 일정 상세보기 게스트 버전 오류 수정
- 일정 메인화면 게스트 버전 프로그래스바 오류 수정

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)

- 비회원
https://github.com/user-attachments/assets/ad3a0b6c-505c-40a4-82af-41fbc608d572

- 회원

https://github.com/user-attachments/assets/25fd2ba1-5eca-4d5e-a354-ecfb3aafa784


## 💬리뷰 요구사항(선택)

- loginstate와 networkstate를 combine으로 합쳐서 collect 하는 방식으로 바꿔봤는데 괜찮은지 모르겠네요...!!
- 그리고 일정 메인페이지에서 로그인 사용자일 경우, 내 일정 api와 공개일정 api 두개를 사용하고 있는데 
   1번째 결과: 성공, 2번째 결과: 실패는 괜찮으나
   1번째 결과: 실패, 2번째 결과: 성공일 경우에는 전체가 성공으로 바뀌어 
   에러상황인데도 성공으로 처리가 될 수 있다고 생각이 들었습니다!
   그래서 viewmodel에서 async와 await를 사용하는 부분으로 바뀌었어요 ! 이 부분 한번 봐주시면 좋을 것 같습니다 👍 
