### PR TITLE
[#194] 홈 지역코드 null값 버그

### DIFF
--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/HomeMainFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/HomeMainFragment.kt
@@ -419,9 +419,7 @@ class HomeMainFragment : Fragment(R.layout.fragment_home_main) {
                             )
                             val address = addresses?.get(0)?.getAddressLine(0)
 
-                            // val (area, sigungu) = splitAddress(address!!)
-                            val area = "인천광역시"
-                            val sigungu = "계양구"
+                            val (area, sigungu) = splitAddress(address!!)
                             binding.homeMyLocationTv.text = "$area $sigungu"
 
                             getAroundPlaceInfo(binding, area, sigungu)
@@ -503,7 +501,7 @@ class HomeMainFragment : Fragment(R.layout.fragment_home_main) {
     }
 
     private fun getRecommendPlaceInfo(binding: FragmentHomeMainBinding) {
-        viewModel.getPlaceMain("1", "1")
+        viewModel.getPlaceMain(DEFAULT_AREA, DEFAULT_SIGUNGU)
 
         viewModel.recommendPlaceInfo.observe(requireActivity()) { recommendPlaceInfo ->
             if (recommendPlaceInfo.isNotEmpty()) {

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/vm/schedule/ScheduleMainViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/vm/schedule/ScheduleMainViewModel.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
-import kr.tekit.lion.domain.exception.HttpException
 import kr.tekit.lion.domain.exception.Result
 import kr.tekit.lion.domain.exception.onError
 import kr.tekit.lion.domain.exception.onSuccess


### PR DESCRIPTION
## #️⃣연관된 이슈

- #194 

## 📝작업 내용

- 추천 여행지 함수에서 api를 호출할 때 default area, default sigungu로 변경

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)


## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  - 주소가 있어도 자꾸 null값으로 불러와서 왜 그런가 했더니 추천 여행지를 불러올 땐 지역이 필요 없어서 임의로 숫자를 string으로 바꿔서 넣어뒀더니 이걸 null 처리 하는거였더라구요..ㅎㅎ 그래서 default area, default sigungu를 넣어서 api 호출하도록 변경했습니다 ~
