### PR TITLE
[#211] 내 일정 목록과 등록 화면 연결 textview height 수정

### DIFF
--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myschedule/MyScheduleActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myschedule/MyScheduleActivity.kt
@@ -18,7 +18,9 @@ import kr.tekit.lion.presentation.ext.addOnScrollEndListener
 import kr.tekit.lion.presentation.ext.showSnackbar
 import kr.tekit.lion.presentation.myschedule.vm.MyScheduleViewModel
 import kr.tekit.lion.presentation.schedule.ResultCode
+import kr.tekit.lion.presentation.schedule.ResultCode.RESULT_SCHEDULE_REVIEW_CANCELED
 import kr.tekit.lion.presentation.schedule.ScheduleDetailActivity
+import kr.tekit.lion.presentation.scheduleform.ScheduleFormActivity
 import kr.tekit.lion.presentation.schedulereview.WriteScheduleReviewActivity
 
 @AndroidEntryPoint
@@ -31,14 +33,19 @@ class MyScheduleActivity : AppCompatActivity() {
 
     private val scheduleLauncher =
         registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->
-            if(result.resultCode == RESULT_CANCELED) return@registerForActivityResult
+            if(result.resultCode == RESULT_SCHEDULE_REVIEW_CANCELED) return@registerForActivityResult
 
             // 일정 목록 갱신
             viewModel.refreshScheduleList()
-
             when (result.resultCode) {
                 ResultCode.RESULT_REVIEW_WRITE -> {
                     binding.root.showSnackbar("후기가 저장되었습니다")
+                }
+                ResultCode.RESULT_SCHEDULE_WRITE -> {
+                    binding.root.showSnackbar("일정이 저장되었습니다")
+                }
+                RESULT_OK -> {
+                    binding.root.showSnackbar("일정이 삭제되었습니다")
                 }
             }
         }
@@ -79,6 +86,7 @@ class MyScheduleActivity : AppCompatActivity() {
         initProgressBarState()
 
         settingToolbar()
+        settingButtonClickListener()
         settingMyScheduleTab()
         settingUpcomingScheduleAdapter()
     }
@@ -112,6 +120,13 @@ class MyScheduleActivity : AppCompatActivity() {
     private fun settingToolbar() {
         binding.toolbarMySchedule.setNavigationOnClickListener {
             finish()
+        }
+    }
+
+    private fun settingButtonClickListener() {
+        binding.textMyScheduleAdd.setOnClickListener {
+            val intent = Intent(this, ScheduleFormActivity::class.java)
+            scheduleLauncher.launch(intent)
         }
     }
 

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/schedule/ResultCode.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/schedule/ResultCode.kt
@@ -4,4 +4,6 @@ object ResultCode {
     const val RESULT_REVIEW_WRITE = 1
     const val RESULT_SCHEDULE_EDIT = 2
     const val RESULT_REVIEW_EDIT = 3
+    const val RESULT_SCHEDULE_WRITE = 4
+    const val RESULT_SCHEDULE_REVIEW_CANCELED = 5
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/ScheduleConfirmFormFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/ScheduleConfirmFormFragment.kt
@@ -88,7 +88,7 @@ class ScheduleConfirmFormFragment : Fragment(R.layout.fragment_schedule_confirm_
         binding.buttonScheduleFormSubmit.setOnClickListener { view ->
             viewModel.submitNewPlan{ _, requestFlag ->
                 if(requestFlag){
-                    requireActivity().setResult(ResultCode.RESULT_SCHEDULE_EDIT)
+                    requireActivity().setResult(ResultCode.RESULT_SCHEDULE_WRITE)
                     requireActivity().finish()
                 }
             }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/schedulereview/WriteScheduleReviewActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/schedulereview/WriteScheduleReviewActivity.kt
@@ -27,6 +27,7 @@ import kr.tekit.lion.presentation.ext.setImage
 import kr.tekit.lion.presentation.ext.showSnackbar
 import kr.tekit.lion.presentation.ext.toAbsolutePath
 import kr.tekit.lion.presentation.main.dialog.ConfirmDialog
+import kr.tekit.lion.presentation.schedule.ResultCode
 import kr.tekit.lion.presentation.schedule.ResultCode.RESULT_REVIEW_WRITE
 import kr.tekit.lion.presentation.schedulereview.adapter.WriteReviewImageAdapter
 import kr.tekit.lion.presentation.schedulereview.vm.WriteScheduleReviewViewModel
@@ -122,7 +123,7 @@ class WriteScheduleReviewActivity : AppCompatActivity() {
 
     private fun initToolbar() {
         binding.toolbarWriteScheduleReview.setNavigationOnClickListener {
-            setResult(RESULT_CANCELED)
+            setResult(ResultCode.RESULT_SCHEDULE_REVIEW_CANCELED)
             finish()
         }
     }

--- a/DaOnGil/presentation/src/main/res/layout/activity_my_schedule.xml
+++ b/DaOnGil/presentation/src/main/res/layout/activity_my_schedule.xml
@@ -69,15 +69,17 @@
 
     <LinearLayout
         android:id="@+id/layout_my_schedule_empty"
-        android:layout_width="match_parent"
-        android:layout_height="0dp"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginHorizontal="@dimen/margin_basic"
         android:gravity="center"
         android:orientation="vertical"
         android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="@+id/recycler_view_my_schedule_list"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/recycler_view_my_schedule_list">
+        app:layout_constraintTop_toBottomOf="@+id/toolbar_my_schedule"
+        tools:visibility="visible">
 
         <TextView
             android:layout_width="wrap_content"
@@ -85,7 +87,7 @@
             android:layout_gravity="center"
             android:text="@string/text_no_schedule"
             android:textColor="@color/text_quaternary"
-            android:textSize="@dimen/font_big2" />
+            android:textSize="@dimen/font_big1" />
 
         <TextView
             android:id="@+id/text_my_schedule_Add"
@@ -99,7 +101,7 @@
             android:paddingVertical="@dimen/margin_small1"
             android:text="@string/add_schedule"
             android:textColor="@color/text_quaternary"
-            android:textSize="@dimen/font_small2" />
+            android:textSize="@dimen/font_big3" />
     </LinearLayout>
 
     <TextView


### PR DESCRIPTION
## #️⃣연관된 이슈

- #211

## 📝작업 내용

- 내 일정 목록에 일정이 없을 때 보여주는 TextView이 보이지 않는 문제 해결했습니다.
- 내 일정 목록에 일정이 없을 때 보여주는 "일정 추가" 버튼과 일정 등록화면 연결
- 일정 목록에서 다른 화면으로 전환 후 다시 돌아왔을 때 처리

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
- 
![Screenshot_1726143301](https://github.com/user-attachments/assets/655cf959-6758-4aa6-abe5-0d95cc01e781)


## 💬리뷰 요구사항(선택)

- view가 보이지 않는 문제가 있는지 몰랐는데, 찾아주신 정민님 감사합니다💖🥰