### PR TITLE
[#221] 카카오 로그인 오류 수정

### DIFF
--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/datasource/AuthDataSource.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/datasource/AuthDataSource.kt
@@ -25,7 +25,7 @@ internal class AuthDataSource @Inject constructor(
         get() = data.map { it.accessToken.isNotBlank() }
 
     suspend fun signIn(type: String, token: String) = runCatching {
-        authService.signIn(type = type, token = token)
+        authService.signIn(type = type, token = "Bearer $token")
     }
 
     suspend fun logout(): Result<Unit> = runCatching {

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/login/vm/LoginViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/login/vm/LoginViewModel.kt
@@ -32,7 +32,7 @@ class LoginViewModel @Inject constructor(
     val isFirstUser = _isFirstUser.asStateFlow()
 
     fun onCompleteLogIn(type: String, token: String) = viewModelScope.launch {
-        authRepository.signIn(type, "Bearer $token")
+        authRepository.signIn(type, token)
         checkIsFirstUser()
         _sigInInUiState.value = true
     }

--- a/DaOnGil/presentation/src/main/res/layout/fragment_login.xml
+++ b/DaOnGil/presentation/src/main/res/layout/fragment_login.xml
@@ -1,68 +1,68 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
 
-    <com.google.android.material.appbar.MaterialToolbar
-        android:id="@+id/materialToolbar"
-        android:layout_width="match_parent"
+    <TextView
+        android:id="@+id/loginTextView"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:background="@color/background_color"
-        android:minHeight="?attr/actionBarSize"
-        android:theme="?attr/actionBarTheme" />
+        android:fontFamily="@font/cafe24_oneprettynight"
+        android:layout_marginTop="@dimen/margin_big1"
+        android:layout_marginEnd="@dimen/margin_big1"
+        android:text="@string/text_hello_plz_login"
+        android:textSize="28dp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
-    <LinearLayout
+
+    <ImageView
+        android:id="@+id/kakaoLoginButton"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:orientation="vertical" >
+        android:layout_height="55dp"
+        android:layout_gravity="center"
+        android:contentDescription="@string/text_kakao_login"
+        android:src="@drawable/kakao_login"
+        android:layout_marginBottom="@dimen/margin_big3"
+        app:layout_constraintBottom_toTopOf="@+id/naverLoginButton"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
-        <TextView
-            android:id="@+id/loginTextView"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="90dp"
-            android:layout_marginStart="@dimen/margin_basic"
-            android:fontFamily="@font/cafe24_oneprettynight"
-            android:textStyle="bold"
-            android:textSize="28dp"
-            android:text="@string/text_hello_plz_login" />
+    <ImageView
+        android:id="@+id/naverLoginButton"
+        android:layout_width="match_parent"
+        android:layout_height="55dp"
+        android:layout_gravity="center"
+        android:contentDescription="@string/text_naver_login"
+        android:fontFamily="@font/pretendard_semibold"
+        android:src="@drawable/naver_login"
+        android:textColor="@color/white"
+        android:layout_marginBottom="@dimen/margin_big3"
+        android:textSize="@dimen/font_big2"
+        app:layout_constraintBottom_toTopOf="@+id/loginTextView3"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
-        <ImageView
-            android:id="@+id/kakaoLoginButton"
-            android:layout_width="wrap_content"
-            android:layout_gravity="center"
-            android:layout_height="55dp"
-            android:layout_marginTop="300dp"
-            android:contentDescription="@string/text_kakao_login"
-            android:src="@drawable/kakao_login" />
+    <TextView
+        android:id="@+id/loginTextView3"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:fontFamily="@font/pretendard_medium"
+        android:text="로그인에 문제가 있나요?"
+        android:textAlignment="center"
+        android:textColor="@color/text_tertiary"
+        android:layout_marginBottom="@dimen/margin_big1"
+        android:textSize="@dimen/font_big3"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
 
-        <ImageView
-            android:id="@+id/naverLoginButton"
-            android:layout_width="wrap_content"
-            android:layout_gravity="center"
-            android:layout_height="55dp"
-            android:layout_marginTop="16dp"
-            android:layout_marginStart="@dimen/margin_basic"
-            android:layout_marginEnd="@dimen/margin_basic"
-            android:src="@drawable/naver_login"
-            android:fontFamily="@font/pretendard_semibold"
-            android:textSize="@dimen/font_big2"
-            android:contentDescription="@string/text_naver_login"
-            android:textColor="@color/white"/>
 
-        <TextView
-            android:id="@+id/loginTextView3"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:layout_marginTop="16dp"
-            android:fontFamily="@font/pretendard_medium"
-            android:text="로그인에 문제가 있나요?"
-            android:textAlignment="center"
-            android:textSize="@dimen/font_big3"
-            android:textColor="@color/text_tertiary"/>
-
-    </LinearLayout>
-
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #221

## 📝작업 내용

- 카카오 로그인이 안되서 확인 해봤는데 키해시가 등록 되어있지 않아 카카오 개발자 센터에 등록해서 해결했습니당
- 카카오 로그인, 네이버 로그인 버튼 길이가 다른거랑 작은 화면에서 로그인 화면이 짤리는 현상 해결했습니다.
+ 애뮬레이터 가장 화면 작은 버전으로 테스트 완료했습니다.
+ 화면은 되도록 ContraintLayout으로 만들자... 알고계실수도 있는데 요 아이는 반응형으로 화면을 조절해줍니다!
- 로그인 화면의 ViewModel에서 Bearer를 붙혀서 토큰 전송을 하는 부분을 수정했습니다.
+ 사소한 부분이지만 Bearer가 Presentation Layer에서 알아야하는 정보는 아니라고 생각해서 DataSource로 변경했습니다.

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)


## 💬리뷰 요구사항(선택)

