### PR TITLE
[#219] 관광 정보 화면 바텀시트 탭 전환시 검색결과가 사라지는 버그 수정

### DIFF
--- a/DaOnGil/presentation/src/main/AndroidManifest.xml
+++ b/DaOnGil/presentation/src/main/AndroidManifest.xml
@@ -63,7 +63,7 @@
             android:name=".myreview.MyReviewActivity"
             android:exported="false" />
         <activity
-            android:name=".DeleteUserActivity"
+            android:name=".myinfo.DeleteUserActivity"
             android:exported="false" />
         <activity
             android:name=".myinfo.MyInfoActivity"

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/MyInfoMainFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/MyInfoMainFragment.kt
@@ -14,7 +14,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
 import kr.tekit.lion.presentation.concerntype.ConcernTypeActivity
-import kr.tekit.lion.presentation.DeleteUserActivity
+import kr.tekit.lion.presentation.myinfo.DeleteUserActivity
 import kr.tekit.lion.presentation.R
 import kr.tekit.lion.presentation.bookmark.BookmarkActivity
 import kr.tekit.lion.presentation.databinding.FragmentMyInfoMainBinding

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/SearchListFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/SearchListFragment.kt
@@ -30,7 +30,7 @@ import kr.tekit.lion.presentation.main.vm.search.SharedViewModel
 @AndroidEntryPoint
 class SearchListFragment : Fragment(R.layout.fragment_search_list) {
     private val sharedViewModel: SharedViewModel by viewModels(ownerProducer = { requireParentFragment() })
-    private val viewModel: SearchListViewModel by activityViewModels()
+    private val viewModel: SearchListViewModel by viewModels()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/model/ListOptionState.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/model/ListOptionState.kt
@@ -25,4 +25,18 @@ data class ListOptionState(
             arrange = arrange
         )
     }
+
+    companion object {
+        fun create(): ListOptionState {
+            return ListOptionState(
+                category = Category.PLACE,
+                page = 0,
+                disabilityType = TreeSet(),
+                detailFilter = TreeSet(),
+                areaCode = null,
+                sigunguCode = null,
+                arrange = SortByLatest.sortCode
+            )
+        }
+    }
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/model/MapOptionState.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/model/MapOptionState.kt
@@ -9,7 +9,7 @@ data class MapOptionState (
     val disabilityType: TreeSet<Long>?,
     val detailFilter: TreeSet<Long>?,
     val arrange: String
-){
+) {
     fun toDomainModel(): MapSearchOption {
         return MapSearchOption(
             category = category.name,
@@ -21,6 +21,23 @@ data class MapOptionState (
             detailFilter = detailFilter?.toList() ?: emptyList(),
             arrange = arrange
         )
+    }
+
+    companion object{
+        fun create(): MapOptionState {
+            return MapOptionState(
+                category = Category.PLACE,
+                location = Locate(
+                    minLatitude = 0.0,
+                    maxLatitude = 0.0,
+                    minLongitude = 0.0,
+                    maxLongitude = 0.0,
+                ),
+                disabilityType = DisabilityType.createDisabilityTypeCodes(),
+                detailFilter = DisabilityType.createFilterCodes(),
+                arrange = SortByLatest.sortCode
+            )
+        }
     }
 }
 

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/vm/search/SearchListViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/vm/search/SearchListViewModel.kt
@@ -78,13 +78,13 @@ class SearchListViewModel @Inject constructor(
     private val _isLastPage = MutableStateFlow(false)
     val isLastPage get() = _isLastPage.asStateFlow()
 
-    private val listOptionState = MutableStateFlow(initListOption())
+    private val listOptionState = MutableStateFlow(ListOptionState.create())
 
     private val areaCode = MutableStateFlow(AreaCodeList(emptyList()))
 
     private val sigunguCode = MutableStateFlow(SigunguCodeList(emptyList()))
 
-    private val mapChanged = MutableSharedFlow<Boolean>()
+    private val mapChanged get() = MutableSharedFlow<Boolean>()
 
     fun onSelectOption(optionCodes: List<Long>, type: DisabilityType) = viewModelScope.launch(Dispatchers.IO) {
         clearPlace()
@@ -359,17 +359,5 @@ class SearchListViewModel @Inject constructor(
                 )
             }
         }
-    }
-
-    private fun initListOption(): ListOptionState {
-        return ListOptionState(
-            category = Category.PLACE,
-            page = 0,
-            disabilityType = TreeSet(),
-            detailFilter = TreeSet(),
-            areaCode = null,
-            sigunguCode = null,
-            arrange = SortByLatest.sortCode
-        )
     }
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/vm/search/SearchMapViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/vm/search/SearchMapViewModel.kt
@@ -50,7 +50,7 @@ class SearchMapViewModel @Inject constructor(
 
     val networkState get() = networkErrorDelegate.networkState
 
-    private val _mapOptionState = MutableStateFlow(initMapOption())
+    private val _mapOptionState = MutableStateFlow(MapOptionState.create())
     val mapOptionState get() = _mapOptionState.asStateFlow()
 
     private val _searchState = MutableSharedFlow<Boolean>()
@@ -149,21 +149,6 @@ class SearchMapViewModel @Inject constructor(
                 )
             }
         }
-    }
-
-    private fun initMapOption(): MapOptionState {
-        return MapOptionState(
-            category = Category.PLACE,
-            location = Locate(
-                minLatitude = 0.0,
-                maxLatitude = 0.0,
-                minLongitude = 0.0,
-                maxLongitude = 0.0,
-            ),
-            disabilityType = DisabilityType.createDisabilityTypeCodes(),
-            detailFilter = DisabilityType.createFilterCodes(),
-            arrange = SortByLatest.sortCode
-        )
     }
 
     fun onClickRestButton(){

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myinfo/DeleteUserActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myinfo/DeleteUserActivity.kt
@@ -1,11 +1,8 @@
-package kr.tekit.lion.presentation
+package kr.tekit.lion.presentation.myinfo
 
 import android.content.Intent
 import android.os.Bundle
-import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import com.kakao.sdk.user.UserApiClient
 import kr.tekit.lion.presentation.databinding.ActivityDeleteUserBinding
 import kr.tekit.lion.presentation.login.LoginActivity

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/setting/PolicyActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/setting/PolicyActivity.kt
@@ -15,7 +15,7 @@ class PolicyActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         with(binding){
-            toolbar.setNavigationOnClickListener {
+            backButton.setOnClickListener {
                 finish()
             }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #219

## 📝작업 내용

-  바텀 시트 탭 전환후 관광 정보 화면으로 돌아올시 검색 결과 초기화 오류 수정

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)

[Screen_recording_20240913_155105.webm](https://github.com/user-attachments/assets/621be2cb-5803-4993-a3f2-168cfd72f77a)

## 💬리뷰 요구사항(선택)

1. 
프래그먼트에서 생명주기를 찍어보니까 onDetatch 까지 호출됩니다. 
기존에 뷰모델은 activityViewModel로 선언되어 있어 프래그먼트가 아닌 액티비티의 생명주기를 따릅니다. 

이 때문에 프래그먼트는 파괴되었지만, 뷰모델은 살아있어 StateFlow가 동일한 값을 방출하지 않아 검색 결과가 사라지는
문제가 발생했습니다. 그래서 액티비티가 아닌 프래그먼트의 생명주기를 따르도록 만들어 해결했습니다.

2. 검색 옵션을 담고있는 Model data Class의 인스턴스를 생성하는 함수를 ViewModel에 위치시켰었는데
뷰모델의 책임을 줄이고자 팩토리 함수를 사용해 Model Class에 만들어 자기 자신의 인스턴스를 생성하는 책임을 가지도록 만들었습니다.


