### PR TITLE
[#226] 관광공사 코드 API 호출 실패시 재시도 로직 추가

### DIFF
--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/splash/SplashActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/splash/SplashActivity.kt
@@ -72,6 +72,17 @@ class SplashActivity : AppCompatActivity() {
                     }
                 }
             }
+
+            repeatOnStarted {
+                viewModel.err.collect{
+                    if (it) {
+                        viewModel.whenUserActivationIsFirst {
+                            startActivity(Intent(this@SplashActivity, OnBoardingActivity::class.java))
+                            finish()
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/splash/vm/SplashViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/splash/vm/SplashViewModel.kt
@@ -4,37 +4,38 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kr.tekit.lion.domain.repository.ActivationRepository
 import kr.tekit.lion.domain.usecase.areacode.InitAreaCodeInfoUseCase
+import kr.tekit.lion.domain.usecase.base.onError
 import kr.tekit.lion.domain.usecase.base.onSuccess
 import javax.inject.Inject
 
 @HiltViewModel
 class SplashViewModel @Inject constructor(
-    private val activationRepository: ActivationRepository,
+    activationRepository: ActivationRepository,
     private val initAreaCodeInfoUseCase: InitAreaCodeInfoUseCase,
 ): ViewModel() {
 
-    private val _userActivationState = MutableSharedFlow<Boolean>()
-    val userActivationState = _userActivationState.asSharedFlow()
+    private val _err = MutableSharedFlow<Boolean>()
+    val err = _err.asSharedFlow()
 
-    init {
-        viewModelScope.launch {
-            checkFirstLogIn()
-        }
-    }
-
-    private fun checkFirstLogIn() = viewModelScope.launch {
-        activationRepository.userActivation.collect{
-            _userActivationState.emit(it)
-        }
-    }
+    val userActivationState = activationRepository.userActivation.shareIn(
+        scope = viewModelScope,
+        started = SharingStarted.WhileSubscribed(5000)
+    )
 
     suspend fun whenUserActivationIsFirst(onComplete: () -> Unit){
         initAreaCodeInfoUseCase().onSuccess {
             onComplete()
+        }.onError {
+            viewModelScope.launch {
+                _err.emit(true)
+            }
         }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- #226 

## 📝작업 내용

- 앱 초기 로딩시 API 호출이 실패하는 케이스가 별견되어 에러 발생시 재시도하도록 구현했습니다

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)


## 💬리뷰 요구사항(선택)

