### PR TITLE
[#232] 북마크 목록 네트워크 에러 처리

### DIFF
--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/bookmark/BookmarkActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/bookmark/BookmarkActivity.kt
@@ -17,6 +17,7 @@ import kr.tekit.lion.presentation.bookmark.vm.BookmarkViewModel
 import kr.tekit.lion.presentation.databinding.ActivityBookmarkBinding
 import kr.tekit.lion.presentation.delegate.NetworkState
 import kr.tekit.lion.presentation.ext.repeatOnStarted
+import kr.tekit.lion.presentation.ext.showInfinitySnackBar
 import kr.tekit.lion.presentation.ext.showSnackbar
 import kr.tekit.lion.presentation.home.DetailActivity
 import kr.tekit.lion.presentation.observer.ConnectivityObserver
@@ -62,7 +63,7 @@ class BookmarkActivity : AppCompatActivity() {
                     }
                     is NetworkState.Error -> {
                         if(viewModel.isUpdateError.value == true) {
-                            this@BookmarkActivity.showSnackbar(binding.root, networkState.msg)
+                            this@BookmarkActivity.showInfinitySnackBar(binding.root, networkState.msg)
                         } else {
                             bookmarkProgressBar.visibility = View.GONE
                             tabLayoutBookmark.visibility = View.GONE

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/bookmark/BookmarkActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/bookmark/BookmarkActivity.kt
@@ -8,6 +8,8 @@ import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.tabs.TabLayout
 import com.google.android.material.tabs.TabLayout.OnTabSelectedListener
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
 import kr.tekit.lion.presentation.R
 import kr.tekit.lion.presentation.bookmark.adapter.PlaceBookmarkRVAdapter
 import kr.tekit.lion.presentation.bookmark.adapter.PlanBookmarkRVAdapter
@@ -17,6 +19,8 @@ import kr.tekit.lion.presentation.delegate.NetworkState
 import kr.tekit.lion.presentation.ext.repeatOnStarted
 import kr.tekit.lion.presentation.ext.showSnackbar
 import kr.tekit.lion.presentation.home.DetailActivity
+import kr.tekit.lion.presentation.observer.ConnectivityObserver
+import kr.tekit.lion.presentation.observer.NetworkConnectivityObserver
 import kr.tekit.lion.presentation.schedule.ScheduleDetailActivity
 
 @AndroidEntryPoint
@@ -24,48 +28,84 @@ class BookmarkActivity : AppCompatActivity() {
     private val binding: ActivityBookmarkBinding by lazy {
         ActivityBookmarkBinding.inflate(layoutInflater)
     }
-
     private val viewModel: BookmarkViewModel by viewModels()
+    private val connectivityObserver: ConnectivityObserver by lazy {
+        NetworkConnectivityObserver.getInstance(this)
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
 
+        settingToolbar()
+        settingTabLayout()
+        settingPlaceBookmarkRVAdapter()
+        observeSnackbarMsg()
+
+        repeatOnStarted {
+            supervisorScope {
+                launch { collectBookmarkState() }
+                launch { observeConnectivity() }
+            }
+        }
+    }
+
+    private suspend fun collectBookmarkState() {
         with(binding) {
-            repeatOnStarted {
-                viewModel.networkState.collect { networkState ->
-                    when (networkState) {
-                        is NetworkState.Loading -> {
-                            bookmarkProgressBar.visibility = View.VISIBLE
-                        }
-                        is NetworkState.Success -> {
+            viewModel.networkState.collect { networkState ->
+                when (networkState) {
+                    is NetworkState.Loading -> {
+                        bookmarkProgressBar.visibility = View.VISIBLE
+                    }
+                    is NetworkState.Success -> {
+                        bookmarkProgressBar.visibility = View.GONE
+                    }
+                    is NetworkState.Error -> {
+                        if(viewModel.isUpdateError.value == true) {
+                            this@BookmarkActivity.showSnackbar(binding.root, networkState.msg)
+                        } else {
                             bookmarkProgressBar.visibility = View.GONE
-                        }
-                        is NetworkState.Error -> {
-                            if(viewModel.isUpdateError.value == true) {
-                                this@BookmarkActivity.showSnackbar(binding.root, networkState.msg)
-                            } else {
-                                bookmarkProgressBar.visibility = View.GONE
-                                tabLayoutBookmark.visibility = View.GONE
-                                bookmarkErrorLayout.visibility = View.VISIBLE
-                                bookmarkErrorMsg.text = networkState.msg
-                            }
+                            tabLayoutBookmark.visibility = View.GONE
+                            bookmarkErrorLayout.visibility = View.VISIBLE
+                            bookmarkErrorMsg.text = networkState.msg
                         }
                     }
                 }
             }
         }
+    }
 
+    private suspend fun observeConnectivity() {
+        with(binding) {
+            connectivityObserver.getFlow().collect { connectivity ->
+                when(connectivity) {
+                    ConnectivityObserver.Status.Available -> {
+                        tabLayoutBookmark.visibility = View.VISIBLE
+                        recyclerViewBookmark.visibility = View.VISIBLE
+                        bookmarkErrorLayout.visibility = View.GONE
+                    }
+                    ConnectivityObserver.Status.Unavailable,
+                    ConnectivityObserver.Status.Losing,
+                    ConnectivityObserver.Status.Lost -> {
+                        tabLayoutBookmark.visibility = View.GONE
+                        recyclerViewBookmark.visibility = View.GONE
+                        bookmarkErrorLayout.visibility = View.VISIBLE
+                        val msg = "${getString(R.string.text_network_is_unavailable)}\n" +
+                                "${getString(R.string.text_plz_check_network)} "
+                        bookmarkErrorMsg.text = msg
+                    }
+                }
+            }
+        }
+    }
+
+    private fun observeSnackbarMsg() {
         viewModel.snackbarEvent.observe(this) { message ->
             message?.let {
                 this@BookmarkActivity.showSnackbar(binding.root, it)
                 viewModel.resetSnackbarEvent()
             }
         }
-
-        settingToolbar()
-        settingTabLayout()
-        settingPlaceBookmarkRVAdapter()
     }
 
     private fun settingToolbar() {

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/bookmark/BookmarkActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/bookmark/BookmarkActivity.kt
@@ -84,6 +84,11 @@ class BookmarkActivity : AppCompatActivity() {
                         tabLayoutBookmark.visibility = View.VISIBLE
                         recyclerViewBookmark.visibility = View.VISIBLE
                         bookmarkErrorLayout.visibility = View.GONE
+
+                        if (viewModel.networkState.value is NetworkState.Error) {
+                            viewModel.getPlaceBookmark()
+                            viewModel.getPlanBookmark()
+                        }
                     }
                     ConnectivityObserver.Status.Unavailable,
                     ConnectivityObserver.Status.Losing,

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/bookmark/vm/BookmarkViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/bookmark/vm/BookmarkViewModel.kt
@@ -42,7 +42,7 @@ class BookmarkViewModel @Inject constructor(
         getPlanBookmark()
     }
 
-    private fun getPlaceBookmark() = viewModelScope.launch {
+    fun getPlaceBookmark() = viewModelScope.launch {
         bookmarkRepository.getPlaceBookmark().onSuccess {
             _placeBookmarkList.value = it
             networkErrorDelegate.handleNetworkSuccess()
@@ -51,7 +51,7 @@ class BookmarkViewModel @Inject constructor(
         }
     }
 
-    private fun getPlanBookmark() = viewModelScope.launch {
+    fun getPlanBookmark() = viewModelScope.launch {
         bookmarkRepository.getPlanBookmark().onSuccess {
             _planBookmarkList.value = it
             networkErrorDelegate.handleNetworkSuccess()


### PR DESCRIPTION
## #️⃣연관된 이슈

- #232 

## 📝작업 내용

- 북마크 목록 네트워크 에러 처리

## PR 발행 전 체크 리스트

- [ ] 발행자 확인
- [ ] 프로젝트 설정 확인
- [ ] 라벨 확인

## 스크린샷 (선택)

- 네트워크 에러 처리

https://github.com/user-attachments/assets/b849c452-fe88-44d3-a965-40dc3db8e708

<br/>

- 북마크 업데이트 에러 처리 스낵바 Infinity로 변경
예시는 네트워크 에러로 했지만, 실제 네트워크 에러에는 위 영상처럼 에러 레이아웃이 보여집니다!
<img src="https://github.com/user-attachments/assets/5016663d-320d-4c9b-8e67-05ecadffa967" width=300/>

<br/>
<br/>

- 인터넷 연결이 끊어진 채로 북마크 목록으로 이동한 후 인터넷이 다시 복구 되었을 때 데이터를 가져오지 못 해서 목록을 보여주지 못 한 이슈도 함께 해결했습니다
1. 해결 전
  
[북마크 네트워크 에러 후 목록 못 가져옴.webm](https://github.com/user-attachments/assets/e7bbafa6-9914-4288-8f6b-6a27d4316db5)

2. 해결 후

https://github.com/user-attachments/assets/9b07b493-00b2-4de7-ac99-b5d86765a234


## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  
