### PR TITLE
[#236] 관심 유형 네트워크 에러 처리 데이터 재요청

### DIFF
--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/concerntype/fragment/ConcernTypeFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/concerntype/fragment/ConcernTypeFragment.kt
@@ -78,6 +78,10 @@ class ConcernTypeFragment : Fragment(R.layout.fragment_concern_type) {
                         concernTypeDivider.visibility = View.VISIBLE
                         concernTypeModifyLayout.visibility = View.VISIBLE
                         concernTypeErrorLayout.visibility = View.GONE
+
+                        if(viewModel.networkState.value is NetworkState.Error) {
+                            viewModel.getConcernType()
+                        }
                     }
                     ConnectivityObserver.Status.Unavailable,
                     ConnectivityObserver.Status.Losing,

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/concerntype/vm/ConcernTypeViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/concerntype/vm/ConcernTypeViewModel.kt
@@ -41,7 +41,7 @@ class ConcernTypeViewModel @Inject constructor(
         getConcernType()
     }
 
-    private fun getConcernType() = viewModelScope.launch {
+    fun getConcernType() = viewModelScope.launch {
         memberRepository.getConcernType().onSuccess {
             _concernType.value = it
             networkErrorDelegate.handleNetworkSuccess()


### PR DESCRIPTION
## #️⃣연관된 이슈

- #236 

## 📝작업 내용

- 인터넷 연결이 끊어진 채로 관심 유형으로 이동한 후 인터넷이 다시 복구 되었을 때 데이터를 가져오지 못 해서 사용자의 관심 유형을 보여주지 못 하는 이슈 해결을 위해 데이터 재요청을 하도록 했습니다

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
1. 해결 전

[해결 전.webm](https://github.com/user-attachments/assets/b91667fb-f050-4783-8915-b655d5eaf2cf)

<br/>

2. 해결 후

[해결 후.webm](https://github.com/user-attachments/assets/df5c8c96-9366-4d19-8d0a-0615f7c3c484)


## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

