### PR TITLE
[#239] 내 일정 목록 네트워크 재연결 시 데이터 요청, 접근성 개선

### DIFF
--- a/DaOnGil/presentation/src/main/res/layout/activity_my_schedule.xml
+++ b/DaOnGil/presentation/src/main/res/layout/activity_my_schedule.xml
@@ -17,6 +17,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:navigationContentDescription="@string/text_back_button"
         app:navigationIcon="@drawable/back_icon">
 
         <TextView
@@ -86,7 +87,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:text="@string/text_no_schedule"
-            android:textColor="@color/text_quaternary"
+            android:textColor="@color/text_tertiary"
             android:textSize="@dimen/font_big1" />
 
         <TextView
@@ -98,9 +99,9 @@
             android:contentDescription="@string/text_add_new_schedule"
             android:focusable="true"
             android:paddingHorizontal="@dimen/margin_basic"
-            android:paddingVertical="@dimen/margin_small1"
+            android:paddingVertical="@dimen/margin_big4"
             android:text="@string/add_schedule"
-            android:textColor="@color/text_quaternary"
+            android:textColor="@color/text_tertiary"
             android:textSize="@dimen/font_big3" />
     </LinearLayout>
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- #239 

## 📝작업 내용

- 접근성 개선
- 네트워크 연결 상태 에러 처리

- 네트워크 연결 상태 에러 처리하면서 계속 테스트를 했는데.. 테스트 할때마다 오류나 예외 상황이 계속해서 발견되어서 고치느랴 오래걸렸습니다. 늦어져서 죄송해요.. 


## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)

#### 접근성 개선 사항
- 일정 등록하기 버튼 text color 진하게 수정
- 일정 등록하기 버튼 터치 영역 수정
- 뒤로가기 버튼에 label 설정
- 수정 후, 접근성 검사하면 dp 관련 제안사항만 나옵니다

|접근성 개선 전|개선 후|접근성 테스트 결과|
|:-----:|:-----:|:-----:|
|![before](https://github.com/user-attachments/assets/6ef02057-94c2-4b38-ab32-3e4e0bb834a2)|![after](https://github.com/user-attachments/assets/64fe09f7-0b54-4ad3-9a7e-da9b256b7c51)|![result](https://github.com/user-attachments/assets/fa8e94df-6163-4cda-ba5a-c189966e2ac6)|

#### 네트워크 연결 상태 에러처리
- 처음부터 네트워크 연결이 해제되었다가 다시 연결되었을 경우

https://github.com/user-attachments/assets/9d63a21b-f404-434b-afa6-e01a541127cc

- 다가오는 일정 목록을 보는 중 네트워크 연결이 해제되었다가 다시 연결되었을 경우

https://github.com/user-attachments/assets/3ba1fa86-6528-47c0-9fbe-275fd2604780


- 다녀온 일정 목록을 보는 중 네트워크 연결이 해제되었다가 다시 연결되었을 경우

https://github.com/user-attachments/assets/b75a5fb8-c6ea-4612-8ea4-c0a3a8eafc83



## 💬리뷰 요구사항(선택)

- 테스트를 여러 번 진행한다고 했는데, 혹시 나중에 테스트 해보시다가 예외처리가 필요한 부분 발견하시면 말씀 부탁드립니다!
