### PR TITLE
[#247] 관심 유형 UI 접근성 개선

### DIFF
--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/concerntype/fragment/ConcernTypeFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/concerntype/fragment/ConcernTypeFragment.kt
@@ -103,6 +103,8 @@ class ConcernTypeFragment : Fragment(R.layout.fragment_concern_type) {
         binding.toolbarConcernType.setNavigationOnClickListener {
             requireActivity().finish()
         }
+
+        binding.toolbarConcernType.setNavigationContentDescription(R.string.text_back_button)
     }
 
     private fun observeNickname(binding: FragmentConcernTypeBinding) {

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/concerntype/fragment/ConcernTypeModifyFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/concerntype/fragment/ConcernTypeModifyFragment.kt
@@ -79,10 +79,10 @@ class ConcernTypeModifyFragment : Fragment(R.layout.fragment_concern_type_modify
 
     private fun initView(binding: FragmentConcernTypeModifyBinding) {
         with(binding) {
-            toolbarConcernTypeModify.setNavigationIcon(R.drawable.back_icon)
             toolbarConcernTypeModify.setNavigationOnClickListener {
                 findNavController().popBackStack()
             }
+            toolbarConcernTypeModify.setNavigationContentDescription(R.string.text_back_button)
 
             imageViewConcernTypeModifyPhysical.setOnClickListener {
                 toggleSelection(it as ImageView, R.drawable.physical_no_select, R.drawable.physical_select, binding)

--- a/DaOnGil/presentation/src/main/res/layout/fragment_concern_type.xml
+++ b/DaOnGil/presentation/src/main/res/layout/fragment_concern_type.xml
@@ -21,7 +21,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:fontFamily="@font/pretendard_medium"
-            android:text="관심 유형"
+            android:text="@string/text_interest_type"
             android:textColor="@color/text_primary"
             android:textSize="@dimen/font_big2" />
 
@@ -62,62 +62,77 @@
             app:strokeColor="#a3a3a4"
             app:strokeWidth="0.5dp">
 
-            <LinearLayout
+            <androidx.constraintlayout.widget.ConstraintLayout
                 android:layout_width="match_parent"
-                android:layout_height="match_parent"
-                android:orientation="vertical"
-                android:paddingTop="@dimen/margin_basic"
-                android:paddingBottom="@dimen/margin_basic">
+                android:layout_height="wrap_content"
+                android:layout_marginVertical="@dimen/margin_small1"
+                android:padding="@dimen/margin_big4">
 
-                <LinearLayout
-                    android:layout_width="match_parent"
+                <ImageView
+                    android:id="@+id/imageViewConcernTypePhysical"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:gravity="center"
-                    android:orientation="horizontal"
-                    android:paddingBottom="@dimen/margin_big2">
+                    android:layout_marginStart="@dimen/margin_big4"
+                    android:layout_marginTop="@dimen/margin_small1"
+                    android:contentDescription="@string/text_physical_disability"
+                    android:src="@drawable/cc_unselected_physical_disability_icon"
+                    app:layout_constraintEnd_toStartOf="@id/imageViewConcernTypeVisual"
+                    app:layout_constraintHorizontal_chainStyle="spread"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
 
-                    <ImageView
-                        android:id="@+id/imageViewConcernTypePhysical"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginRight="@dimen/margin_basic"
-                        android:src="@drawable/cc_unselected_physical_disability_icon" />
-
-                    <ImageView
-                        android:id="@+id/imageViewConcernTypeVisual"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginRight="@dimen/margin_basic"
-                        android:src="@drawable/cc_unselected_visual_impairment_icon" />
-
-                    <ImageView
-                        android:id="@+id/imageViewConcernTypeHearing"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:src="@drawable/cc_unselected_hearing_impairment_icon" />
-                </LinearLayout>
-
-                <LinearLayout
-                    android:layout_width="match_parent"
+                <ImageView
+                    android:id="@+id/imageViewConcernTypeVisual"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:gravity="center"
-                    android:orientation="horizontal">
+                    android:layout_margin="@dimen/margin_small1"
+                    android:contentDescription="@string/text_visual_impairment"
+                    android:src="@drawable/cc_unselected_visual_impairment_icon"
+                    app:layout_constraintEnd_toStartOf="@id/imageViewConcernTypeHearing"
+                    app:layout_constraintStart_toEndOf="@id/imageViewConcernTypePhysical"
+                    app:layout_constraintTop_toTopOf="parent" />
 
-                    <ImageView
-                        android:id="@+id/imageViewConcernTypeInfant"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_marginRight="@dimen/margin_basic"
-                        android:src="@drawable/cc_unselected_infant_family_icon" />
+                <ImageView
+                    android:id="@+id/imageViewConcernTypeHearing"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_small1"
+                    android:layout_marginEnd="@dimen/margin_big4"
+                    android:contentDescription="@string/text_hearing_impairment"
+                    android:src="@drawable/cc_unselected_hearing_impairment_icon"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/imageViewConcernTypeVisual"
+                    app:layout_constraintTop_toTopOf="parent" />
 
-                    <ImageView
-                        android:id="@+id/imageViewConcernTypeElderly"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:src="@drawable/cc_unselected_elderly_people_icon" />
-                </LinearLayout>
+                <ImageView
+                    android:id="@+id/imageViewConcernTypeInfant"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginVertical="@dimen/margin_small1"
+                    android:layout_marginStart="@dimen/margin_big1"
+                    android:paddingTop="@dimen/margin_small1"
+                    android:contentDescription="@string/text_infant_family"
+                    android:src="@drawable/cc_unselected_infant_family_icon"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toStartOf="@id/imageViewConcernTypeElderly"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/imageViewConcernTypePhysical" />
 
-            </LinearLayout>
+                <ImageView
+                    android:id="@+id/imageViewConcernTypeElderly"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginVertical="@dimen/margin_small1"
+                    android:layout_marginEnd="@dimen/margin_big1"
+                    android:paddingTop="@dimen/margin_small1"
+                    android:contentDescription="@string/text_elderly_person"
+                    android:src="@drawable/cc_unselected_elderly_people_icon"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/imageViewConcernTypeInfant"
+                    app:layout_constraintTop_toBottomOf="@id/imageViewConcernTypeVisual" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
 
         </com.google.android.material.card.MaterialCardView>
 
@@ -149,7 +164,7 @@
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/margin_basic"
             android:fontFamily="@font/pretendard_medium"
-            android:text="관심 유형을 변경하고 싶으신가요?"
+            android:text="@string/text_concern_type_subtitle"
             android:textSize="@dimen/font_big2" />
 
         <Button
@@ -157,8 +172,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@drawable/background_radius_10"
-            android:fontFamily="@font/pretendard_bold"
-            android:text="관심 유형 수정하기"
+            android:fontFamily="@font/pretendard_extrabold"
+            android:text="@string/text_concern_type_modify_move"
             android:textSize="@dimen/font_big2" />
     </LinearLayout>
 
@@ -177,6 +192,7 @@
         <ImageView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:contentDescription="@null"
             app:srcCompat="@drawable/onboarding_clover" />
 
         <TextView

--- a/DaOnGil/presentation/src/main/res/layout/fragment_concern_type_modify.xml
+++ b/DaOnGil/presentation/src/main/res/layout/fragment_concern_type_modify.xml
@@ -8,14 +8,15 @@
         android:id="@+id/toolbarConcernTypeModify"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:minHeight="?attr/actionBarSize">
+        android:minHeight="?attr/actionBarSize"
+        app:navigationIcon="@drawable/back_icon">
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:fontFamily="@font/pretendard_medium"
-            android:text="관심 유형"
+            android:text="@string/text_interest_type"
             android:textColor="@color/text_primary"
             android:textSize="@dimen/font_big2" />
 
@@ -28,7 +29,7 @@
         android:layout_marginHorizontal="@dimen/margin_basic"
         android:layout_marginTop="@dimen/margin_big2"
         android:fontFamily="@font/pretendard_medium"
-        android:text="관심 유형을 선택해주세요"
+        android:text="@string/text_concern_type_choose"
         android:textSize="@dimen/font_big2" />
 
     <ScrollView
@@ -51,6 +52,7 @@
                     android:id="@+id/imageViewConcernTypeModifyPhysical"
                     android:layout_width="0dp"
                     android:layout_height="0dp"
+                    android:contentDescription="@string/text_physical_disability"
                     android:src="@drawable/physical_no_select"
                     android:tag="false"
                     app:layout_constraintBottom_toBottomOf="parent"
@@ -66,6 +68,7 @@
                     android:id="@+id/imageViewConcernTypeModifyVisual"
                     android:layout_width="0dp"
                     android:layout_height="0dp"
+                    android:contentDescription="@string/text_visual_impairment"
                     android:src="@drawable/visual_no_select"
                     android:tag="false"
                     app:layout_constraintBottom_toBottomOf="parent"
@@ -87,6 +90,7 @@
                     android:id="@+id/imageViewConcernTypeModifyHearing"
                     android:layout_width="0dp"
                     android:layout_height="0dp"
+                    android:contentDescription="@string/text_hearing_impairment"
                     android:src="@drawable/hearing_no_select"
                     android:tag="false"
                     app:layout_constraintBottom_toBottomOf="parent"
@@ -101,6 +105,7 @@
                     android:id="@+id/imageViewConcernTypeModifyInfant"
                     android:layout_width="0dp"
                     android:layout_height="0dp"
+                    android:contentDescription="@string/text_infant_family"
                     android:src="@drawable/infant_family_no_select"
                     android:tag="false"
                     app:layout_constraintBottom_toBottomOf="parent"
@@ -121,6 +126,7 @@
                     android:id="@+id/imageViewConcernTypeModifyElderly"
                     android:layout_width="0dp"
                     android:layout_height="0dp"
+                    android:contentDescription="@string/text_elderly_person"
                     android:src="@drawable/elderly_people_no_select"
                     android:tag="false"
                     app:layout_constraintBottom_toBottomOf="parent"
@@ -135,6 +141,7 @@
                     android:id="@+id/imageViewEtc"
                     android:layout_width="0dp"
                     android:layout_height="0dp"
+                    android:contentDescription="@null"
                     android:src="@drawable/infant_family_no_select"
                     android:tag="false"
                     android:visibility="invisible"
@@ -159,8 +166,8 @@
         android:layout_marginHorizontal="@dimen/margin_basic"
         android:layout_marginBottom="@dimen/margin_big2"
         android:background="@drawable/background_radius_10"
-        android:fontFamily="@font/pretendard_bold"
-        android:text="수정하기"
+        android:fontFamily="@font/pretendard_extrabold"
+        android:text="@string/text_concern_type_modify"
         android:textSize="@dimen/font_big2" />
 
 </LinearLayout>

--- a/DaOnGil/presentation/src/main/res/values/strings.xml
+++ b/DaOnGil/presentation/src/main/res/values/strings.xml
@@ -385,4 +385,9 @@
     <string name="text_update_bookmark">북마크 취소하기</string>
     <string name="text_bookmark_img">여행지 이미지</string>
     <string name="text_bookmark_profile_img">프로필 이미지</string>
+
+    <string name="text_concern_type_subtitle">관심 유형을 변경하고 싶으신가요?</string>
+    <string name="text_concern_type_modify_move">관심 유형 수정하기</string>
+    <string name="text_concern_type_choose">관심 유형을 선택해주세요.</string>
+    <string name="text_concern_type_modify">수정하기</string>
 </resources>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #247 

## 📝작업 내용
- 관심 유형 이미지 레이아웃 수정
- 버튼 텍스트 extraBold로 수정
- contentDescription 설정

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
- 작은 화면의 기기에서 관심 유형 이미지 크기가 달라지는 이슈 해결

| 수정 전 | 수정 후 | 디스플레이 확대 최대일 때도 똑같은 이미지 크기 |
|---|---|---|
| <img src="https://github.com/user-attachments/assets/8d7cf852-7e84-4919-85da-e2cb32f21966"/> | <img src="https://github.com/user-attachments/assets/9b500296-9e03-413f-a608-b6fbb4514817"/> | <img src="https://github.com/user-attachments/assets/2c9f3e14-a8d9-4092-9a0c-3ac3ea2d0759"/>|

<br>

- 버튼 텍스트 extraBold로 수정
기존에 이미 텍스트 굵기가 Bold로 되어있어서 extraBold로 설정했습니다
<img src="https://github.com/user-attachments/assets/049eecf6-832f-47a6-941f-8be0b29907911" width=30%/>
<img src="https://github.com/user-attachments/assets/73022656-0ddb-4e8a-87e9-2bd450659701" width=30%/>


## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  
