### PR TITLE
[#238] 관광지 상세보기 UI 수정

### DIFF
--- a/DaOnGil/presentation/src/main/res/drawable-night/detail_address_icon.xml
+++ b/DaOnGil/presentation/src/main/res/drawable-night/detail_address_icon.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="15dp"
-    android:height="15dp"
+    android:width="20dp"
+    android:height="20dp"
     android:viewportWidth="15"
     android:viewportHeight="15">
   <path

--- a/DaOnGil/presentation/src/main/res/drawable-night/detail_call_icon.xml
+++ b/DaOnGil/presentation/src/main/res/drawable-night/detail_call_icon.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="15dp"
-    android:height="15dp"
+    android:width="20dp"
+    android:height="20dp"
     android:viewportWidth="15"
     android:viewportHeight="15">
   <path

--- a/DaOnGil/presentation/src/main/res/drawable-night/detail_link_icon.xml
+++ b/DaOnGil/presentation/src/main/res/drawable-night/detail_link_icon.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="15dp"
-    android:height="15dp"
+    android:width="20dp"
+    android:height="20dp"
     android:viewportWidth="15"
     android:viewportHeight="15">
   <group>

--- a/DaOnGil/presentation/src/main/res/drawable-night/detail_review_modify_icon.xml
+++ b/DaOnGil/presentation/src/main/res/drawable-night/detail_review_modify_icon.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="59dp"
-    android:height="24dp"
+    android:width="65dp"
+    android:height="30dp"
     android:viewportWidth="59"
     android:viewportHeight="24">
   <path

--- a/DaOnGil/presentation/src/main/res/drawable-night/info_icon.xml
+++ b/DaOnGil/presentation/src/main/res/drawable-night/info_icon.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="18dp"
-    android:height="18dp"
+    android:width="20dp"
+    android:height="20dp"
     android:viewportWidth="18"
     android:viewportHeight="18">
   <path

--- a/DaOnGil/presentation/src/main/res/drawable/detail_address_icon.xml
+++ b/DaOnGil/presentation/src/main/res/drawable/detail_address_icon.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="15dp"
-    android:height="15dp"
+    android:width="20dp"
+    android:height="20dp"
     android:viewportWidth="15"
     android:viewportHeight="15">
   <path

--- a/DaOnGil/presentation/src/main/res/drawable/detail_call_icon.xml
+++ b/DaOnGil/presentation/src/main/res/drawable/detail_call_icon.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="15dp"
-    android:height="15dp"
+    android:width="20dp"
+    android:height="20dp"
     android:viewportWidth="15"
     android:viewportHeight="15">
   <path

--- a/DaOnGil/presentation/src/main/res/drawable/detail_link_icon.xml
+++ b/DaOnGil/presentation/src/main/res/drawable/detail_link_icon.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="15dp"
-    android:height="15dp"
+    android:width="20dp"
+    android:height="20dp"
     android:viewportWidth="15"
     android:viewportHeight="15">
   <group>

--- a/DaOnGil/presentation/src/main/res/drawable/detail_review_modify_icon.xml
+++ b/DaOnGil/presentation/src/main/res/drawable/detail_review_modify_icon.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="59dp"
-    android:height="24dp"
+    android:width="65dp"
+    android:height="30dp"
     android:viewportWidth="59"
     android:viewportHeight="24">
   <path

--- a/DaOnGil/presentation/src/main/res/drawable/info_icon.xml
+++ b/DaOnGil/presentation/src/main/res/drawable/info_icon.xml
@@ -1,6 +1,6 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="18dp"
-    android:height="18dp"
+    android:width="20dp"
+    android:height="20dp"
     android:viewportWidth="18"
     android:viewportHeight="18">
   <path

--- a/DaOnGil/presentation/src/main/res/layout/activity_detail.xml
+++ b/DaOnGil/presentation/src/main/res/layout/activity_detail.xml
@@ -57,7 +57,7 @@
                     android:fontFamily="@font/pretendard_bold"
                     android:text="관광지명"
                     android:textColor="@color/white"
-                    android:textSize="@dimen/font_big1"
+                    android:textSize="@dimen/font_big0"
                     app:layout_constraintBottom_toTopOf="@+id/detail_address_tv"
                     app:layout_constraintEnd_toEndOf="@+id/detail_address_tv"
                     app:layout_constraintStart_toStartOf="@+id/detail_address_tv" />
@@ -71,7 +71,7 @@
                     android:fontFamily="@font/pretendard_medium"
                     android:text="주소"
                     android:textColor="@color/white"
-                    android:textSize="@dimen/font_big3"
+                    android:textSize="@dimen/font_big2"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent" />
@@ -132,7 +132,7 @@
                     android:fontFamily="@font/pretendard_regular"
                     android:text="홈 > 무장애 관광정보 > "
                     android:textColor="@color/text_secondary"
-                    android:textSize="@dimen/font_big3"
+                    android:textSize="@dimen/font_big1"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toTopOf="parent" />
 
@@ -143,7 +143,7 @@
                     android:fontFamily="@font/pretendard_regular"
                     android:text="관광지"
                     android:textColor="@color/text_secondary"
-                    android:textSize="@dimen/font_big3"
+                    android:textSize="@dimen/font_big1"
                     app:layout_constraintBottom_toBottomOf="@+id/detail_route_tv"
                     app:layout_constraintStart_toEndOf="@+id/detail_route_tv"
                     app:layout_constraintTop_toTopOf="@id/detail_route_tv" />
@@ -168,7 +168,7 @@
                     android:fontFamily="@font/pretendard_semibold"
                     android:text="기본 정보"
                     android:textColor="@color/text_secondary"
-                    android:textSize="@dimen/font_big2"
+                    android:textSize="@dimen/font_big0"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@id/detail_basic_divider" />
 
@@ -199,7 +199,7 @@
                     android:lineSpacingMultiplier="1.2"
                     android:text="기본 정보 내용"
                     android:textColor="@color/text_secondary"
-                    android:textSize="@dimen/font_small1"
+                    android:textSize="@dimen/font_big2"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toStartOf="parent"
                     app:layout_constraintTop_toBottomOf="@+id/detail_map_layout" />
@@ -221,7 +221,7 @@
                     android:fontFamily="@font/pretendard_medium"
                     android:text="주소"
                     android:textColor="@color/text_primary"
-                    android:textSize="@dimen/font_big3"
+                    android:textSize="@dimen/font_big1"
                     app:layout_constraintBottom_toBottomOf="@+id/detail_address_iv"
                     app:layout_constraintStart_toEndOf="@+id/detail_address_iv"
                     app:layout_constraintTop_toTopOf="@+id/detail_address_iv" />
@@ -236,7 +236,7 @@
                     android:fontFamily="@font/pretendard_medium"
                     android:text="주소입니다"
                     android:textColor="@color/text_secondary"
-                    android:textSize="@dimen/font_small1"
+                    android:textSize="@dimen/font_big2"
                     app:layout_constraintEnd_toEndOf="parent"
                     app:layout_constraintStart_toEndOf="@+id/detail_basic_address_tv"
                     app:layout_constraintTop_toTopOf="@+id/detail_basic_address_tv" />
@@ -258,7 +258,7 @@
                     android:fontFamily="@font/pretendard_medium"
                     android:text="문의"
                     android:textColor="@color/text_primary"
-                    android:textSize="@dimen/font_big3"
+                    android:textSize="@dimen/font_big1"
                     app:layout_constraintStart_toEndOf="@+id/detail_call_iv"
                     app:layout_constraintTop_toTopOf="@+id/detail_call_content_tv" />
 
@@ -271,7 +271,7 @@
                     android:fontFamily="@font/pretendard_medium"
                     android:text="010-1111-1111"
                     android:textColor="@color/text_secondary"
-                    android:textSize="@dimen/font_small1"
+                    android:textSize="@dimen/font_big2"
                     app:layout_constraintEnd_toEndOf="@+id/detail_basic_address_content_tv"
                     app:layout_constraintStart_toStartOf="@+id/detail_basic_address_content_tv"
                     app:layout_constraintTop_toBottomOf="@+id/detail_basic_address_content_tv" />
@@ -293,7 +293,7 @@
                     android:fontFamily="@font/pretendard_medium"
                     android:text="링크"
                     android:textColor="@color/text_primary"
-                    android:textSize="@dimen/font_big3"
+                    android:textSize="@dimen/font_big1"
                     app:layout_constraintStart_toEndOf="@+id/detail_link_iv"
                     app:layout_constraintTop_toTopOf="@+id/detail_homepage_content_tv" />
 
@@ -306,7 +306,7 @@
                     android:fontFamily="@font/pretendard_medium"
                     android:text="링크 url"
                     android:textColor="@color/text_secondary"
-                    android:textSize="@dimen/font_small1"
+                    android:textSize="@dimen/font_big2"
                     app:layout_constraintEnd_toEndOf="@+id/detail_call_content_tv"
                     app:layout_constraintStart_toStartOf="@+id/detail_call_content_tv"
                     app:layout_constraintTop_toBottomOf="@+id/detail_call_content_tv" />
@@ -319,7 +319,7 @@
                     android:fontFamily="@font/pretendard_semibold"
                     android:text="무장애 편의정보"
                     android:textColor="@color/text_secondary"
-                    android:textSize="@dimen/font_big2"
+                    android:textSize="@dimen/font_big0"
                     app:layout_constraintStart_toStartOf="@id/detail_link_iv"
                     app:layout_constraintTop_toBottomOf="@id/detail_homepage_content_tv" />
 
@@ -351,7 +351,7 @@
                     android:fontFamily="@font/pretendard_semibold"
                     android:text="후기"
                     android:textColor="@color/text_secondary"
-                    android:textSize="@dimen/font_big2"
+                    android:textSize="@dimen/font_big0"
                     app:layout_constraintStart_toStartOf="@+id/detail_disability_info_rv"
                     app:layout_constraintTop_toBottomOf="@+id/detail_disability_info_rv" />
 
@@ -398,7 +398,7 @@
                     android:fontFamily="@font/pretendard_medium"
                     android:text="현재 작성된 리뷰가 없습니다"
                     android:textColor="@color/text_secondary"
-                    android:textSize="@dimen/font_small1"
+                    android:textSize="@dimen/font_big2"
                     android:visibility="visible"
                     app:layout_constraintBottom_toTopOf="@id/detail_more_review_btn"
                     app:layout_constraintEnd_toEndOf="parent"

--- a/DaOnGil/presentation/src/main/res/layout/item_detail_service_info.xml
+++ b/DaOnGil/presentation/src/main/res/layout/item_detail_service_info.xml
@@ -16,7 +16,7 @@
 
     <TextView
         android:id="@+id/item_detail_info_title_tv"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/margin_small1"
         android:fontFamily="@font/pretendard_semibold"
@@ -24,6 +24,7 @@
         android:textColor="@color/text_primary"
         android:textSize="@dimen/font_big2"
         app:layout_constraintBottom_toBottomOf="@id/item_detail_info_iv"
+        app:layout_constraintEnd_toStartOf="@+id/item_detail_info_guideline"
         app:layout_constraintStart_toEndOf="@+id/item_detail_info_iv"
         app:layout_constraintTop_toTopOf="@+id/item_detail_info_iv" />
 
@@ -31,13 +32,20 @@
         android:id="@+id/item_detail_info_content_tv"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="150dp"
+        android:layout_marginStart="@dimen/margin_small1"
         android:fontFamily="@font/pretendard_medium"
         android:text="시설 정보"
         android:textColor="@color/text_secondary"
         android:textSize="@dimen/font_big2"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/item_detail_info_guideline"
         app:layout_constraintTop_toTopOf="@id/item_detail_info_title_tv" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/item_detail_info_guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_percent="0.35" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/DaOnGil/presentation/src/main/res/layout/item_detail_service_info.xml
+++ b/DaOnGil/presentation/src/main/res/layout/item_detail_service_info.xml
@@ -22,7 +22,7 @@
         android:fontFamily="@font/pretendard_semibold"
         android:text="편의 시설"
         android:textColor="@color/text_primary"
-        android:textSize="@dimen/font_small1"
+        android:textSize="@dimen/font_big2"
         app:layout_constraintBottom_toBottomOf="@id/item_detail_info_iv"
         app:layout_constraintStart_toEndOf="@+id/item_detail_info_iv"
         app:layout_constraintTop_toTopOf="@+id/item_detail_info_iv" />
@@ -35,7 +35,7 @@
         android:fontFamily="@font/pretendard_medium"
         android:text="시설 정보"
         android:textColor="@color/text_secondary"
-        android:textSize="@dimen/font_small1"
+        android:textSize="@dimen/font_big2"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@id/item_detail_info_title_tv" />

--- a/DaOnGil/presentation/src/main/res/values/dimens.xml
+++ b/DaOnGil/presentation/src/main/res/values/dimens.xml
@@ -19,6 +19,7 @@
     <dimen name="font_small2">12dp</dimen>
     <dimen name="font_small3">10dp</dimen>
 
+    <dimen name="font_big0">24dp</dimen>
     <dimen name="font_big1">20dp</dimen>
     <dimen name="font_big2">18dp</dimen>
     <dimen name="font_big3">16dp</dimen>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #238

## 📝작업 내용

- 관광지 상세보기 접근성 이슈로 전체 폰트 크기 수정했습니다

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)

https://github.com/user-attachments/assets/2e0e002f-51c0-4853-b2fc-e67d05f0fe29

- +) 위 영상에서 무장애 관광정보 텍스트 겹침 수정했습니다

<img src="https://github.com/user-attachments/assets/f7bc0b15-9476-4c51-943c-4ad24fbc499d" width="40%" height="40%"/>


## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  - 내용 텍스트 (14dp -> 18dp), 소제목 텍스트 (18dp -> 24dp)는 회의에서 얘기한대로 변경했더니 그 외의 텍스트들은 그냥 두니 이질감이 들어서 나머지 텍스트들도 제가 임의로 크기 조정을 해보았는데 (후기 제외) 영상 보고 너무 어색한 부분 있으면 말씀해주세요!
