### PR TITLE
[#263] 관광지 리뷰 네트워크 에러처리

### DIFF
--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/ext/ActivityExt.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/ext/ActivityExt.kt
@@ -1,0 +1,12 @@
+package kr.tekit.lion.presentation.ext
+
+import android.app.Activity
+import android.widget.TextView
+import androidx.annotation.ColorRes
+import androidx.core.content.ContextCompat
+import com.google.android.material.appbar.MaterialToolbar
+
+fun Activity.updateToolbarColors(toolbarTitle: TextView, toolbar: MaterialToolbar, @ColorRes colorRes: Int) {
+    toolbarTitle.setTextColor(ContextCompat.getColor(this, colorRes))
+    toolbar.navigationIcon?.setTint(ContextCompat.getColor(this, colorRes))
+}

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/ext/ViewExt.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/ext/ViewExt.kt
@@ -45,3 +45,8 @@ fun View.setAccessibilityText(newText: CharSequence) {
     }
 }
 
+fun View.updateVisibility(isVisible: Boolean, vararg views: View) {
+    views.forEach {
+        it.visibility = if (isVisible) View.VISIBLE else View.GONE
+    }
+}

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/ReviewListActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/ReviewListActivity.kt
@@ -6,11 +6,13 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.bumptech.glide.Glide
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
 import kr.tekit.lion.domain.model.placereviewlist.PlaceReview
 import kr.tekit.lion.presentation.R
 import kr.tekit.lion.presentation.databinding.ActivityReviewListBinding
@@ -18,8 +20,12 @@ import kr.tekit.lion.presentation.delegate.NetworkState
 import kr.tekit.lion.presentation.ext.addOnScrollEndListener
 import kr.tekit.lion.presentation.ext.repeatOnStarted
 import kr.tekit.lion.presentation.ext.showSnackbar
+import kr.tekit.lion.presentation.ext.updateToolbarColors
+import kr.tekit.lion.presentation.ext.updateVisibility
 import kr.tekit.lion.presentation.home.adapter.ReviewListRVAdapter
 import kr.tekit.lion.presentation.home.vm.ReviewListViewModel
+import kr.tekit.lion.presentation.observer.ConnectivityObserver
+import kr.tekit.lion.presentation.observer.NetworkConnectivityObserver
 import kr.tekit.lion.presentation.splash.model.LogInState
 
 @AndroidEntryPoint
@@ -27,6 +33,9 @@ class ReviewListActivity : AppCompatActivity() {
     private val viewModel: ReviewListViewModel by viewModels()
     private val binding: ActivityReviewListBinding by lazy {
         ActivityReviewListBinding.inflate(layoutInflater)
+    }
+    private val connectivityObserver: ConnectivityObserver by lazy {
+        NetworkConnectivityObserver.getInstance(this)
     }
 
     private val reportLauncher =
@@ -47,58 +56,10 @@ class ReviewListActivity : AppCompatActivity() {
         settingToolbar()
 
         repeatOnStarted {
-            launch {
-                viewModel.loginState.collect { uiState ->
-                    when (uiState) {
-                        is LogInState.Checking -> {
-                            return@collect
-                        }
-
-                        is LogInState.LoggedIn -> {
-                            getReviewListInfo(placeId)
-                        }
-
-                        is LogInState.LoginRequired -> {
-                            getReviewListInfoGuest(placeId)
-                        }
-                    }
-                }
-            }
-
-            launch {
-                viewModel.networkState.collectLatest { state ->
-                    when (state) {
-                        is NetworkState.Loading -> {
-                            binding.reviewListErrorLayout.visibility = View.GONE
-                        }
-
-                        is NetworkState.Success -> {
-                            binding.reviewListErrorLayout.visibility = View.GONE
-                        }
-
-                        is NetworkState.Error -> {
-                            binding.reviewListToolbarTitleTv.setTextColor(
-                                ContextCompat.getColor(
-                                    applicationContext,
-                                    R.color.text_primary
-                                )
-                            )
-                            binding.reviewListToolbar.navigationIcon?.setTint(
-                                ContextCompat.getColor(
-                                    applicationContext,
-                                    R.color.text_primary
-                                )
-                            )
-                            binding.reviewListThumbnailDark.visibility = View.GONE
-                            binding.reviewListThumbnailIv.visibility = View.GONE
-                            binding.reviewListTitleTv.visibility = View.GONE
-                            binding.reviewListAddressTv.visibility = View.GONE
-                            binding.reviewListContentLayout.visibility = View.GONE
-                            binding.reviewListErrorLayout.visibility = View.VISIBLE
-                            binding.reviewListErrorTv.text = state.msg
-                        }
-                    }
-                }
+            supervisorScope {
+                launch { collectLoginState(placeId) }
+                launch { collectReviewNetworkState() }
+                launch { observeConnectivity(placeId) }
             }
         }
     }
@@ -161,4 +122,102 @@ class ReviewListActivity : AppCompatActivity() {
             settingReviewListRVAdapter(placeReviewInfo.placeReviewList, false)
         }
     }
+
+    private suspend fun collectLoginState(placeId: Long) {
+        viewModel.loginState.collect { uiState ->
+            when (uiState) {
+                is LogInState.Checking -> {
+                    return@collect
+                }
+
+                is LogInState.LoggedIn -> {
+                    getReviewListInfo(placeId)
+                }
+
+                is LogInState.LoginRequired -> {
+                    getReviewListInfoGuest(placeId)
+                }
+            }
+        }
+    }
+
+    private suspend fun collectReviewNetworkState() {
+        with(binding) {
+            viewModel.networkState.collectLatest { state ->
+                when (state) {
+                    is NetworkState.Loading -> {
+                        reviewListErrorLayout.visibility = View.GONE
+                    }
+
+                    is NetworkState.Success -> {
+                        reviewListErrorLayout.visibility = View.GONE
+                    }
+
+                    is NetworkState.Error -> {
+                        this@ReviewListActivity.updateToolbarColors(
+                            reviewListToolbarTitleTv,
+                            reviewListToolbar,
+                            R.color.text_primary
+                        )
+
+                        root.updateVisibility(
+                            isVisible = false,
+                            reviewListThumbnailDark, reviewListThumbnailIv, reviewListTitleTv,
+                            reviewListAddressTv, reviewListContentLayout
+                        )
+                        binding.reviewListErrorLayout.visibility = View.VISIBLE
+                        binding.reviewListErrorTv.text = state.msg
+                    }
+                }
+            }
+        }
+    }
+
+    private suspend fun observeConnectivity(placeId: Long) {
+        with(binding) {
+            connectivityObserver.getFlow().collect { connectivity ->
+                when (connectivity) {
+                    ConnectivityObserver.Status.Available -> {
+                        reviewListErrorLayout.visibility = View.GONE
+
+                        this@ReviewListActivity.updateToolbarColors(
+                            reviewListToolbarTitleTv,
+                            reviewListToolbar,
+                            R.color.white
+                        )
+                        root.updateVisibility(
+                            isVisible = true,
+                            reviewListThumbnailDark, reviewListThumbnailIv, reviewListTitleTv,
+                            reviewListAddressTv, reviewListContentLayout
+                        )
+
+                        if (viewModel.networkState.value is NetworkState.Error) {
+                            lifecycleScope.launch {
+                                collectLoginState(placeId)
+                            }
+                        }
+                    }
+                    // Unavailable, Losing, Lost
+                    else -> {
+                        val msg = "${getString(R.string.text_network_is_unavailable)}\n" +
+                                "${getString(R.string.text_plz_check_network)} "
+
+                        this@ReviewListActivity.updateToolbarColors(
+                            reviewListToolbarTitleTv,
+                            reviewListToolbar,
+                            R.color.text_primary
+                        )
+                        root.updateVisibility(
+                            isVisible = false,
+                            reviewListThumbnailDark, reviewListThumbnailIv, reviewListTitleTv,
+                            reviewListAddressTv, reviewListContentLayout
+                        )
+                        reviewListErrorLayout.visibility = View.VISIBLE
+                        reviewListErrorTv.text = msg
+                    }
+                }
+            }
+        }
+    }
+
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/WriteReviewActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/WriteReviewActivity.kt
@@ -23,16 +23,19 @@ import com.google.android.material.snackbar.Snackbar
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
 import kr.tekit.lion.presentation.R
 import kr.tekit.lion.presentation.databinding.ActivityWriteReviewBinding
 import kr.tekit.lion.presentation.delegate.NetworkState
 import kr.tekit.lion.presentation.ext.repeatOnStarted
-import kr.tekit.lion.presentation.ext.showSnackbar
+import kr.tekit.lion.presentation.ext.showInfinitySnackBar
 import kr.tekit.lion.presentation.ext.showSoftInput
 import kr.tekit.lion.presentation.ext.toAbsolutePath
 import kr.tekit.lion.presentation.home.adapter.WriteReviewImageRVAdapter
 import kr.tekit.lion.presentation.home.vm.WriteReviewViewModel
 import kr.tekit.lion.presentation.main.dialog.ConfirmDialog
+import kr.tekit.lion.presentation.observer.ConnectivityObserver
+import kr.tekit.lion.presentation.observer.NetworkConnectivityObserver
 import java.time.Instant
 import java.time.LocalDate
 import java.time.ZoneId
@@ -47,6 +50,9 @@ class WriteReviewActivity : AppCompatActivity() {
     private val viewModel: WriteReviewViewModel by viewModels()
     private val selectedImages: ArrayList<Uri> = ArrayList()
     private lateinit var imageRVAdapter: WriteReviewImageRVAdapter
+    private val connectivityObserver: ConnectivityObserver by lazy {
+        NetworkConnectivityObserver.getInstance(this)
+    }
 
     @SuppressLint("NotifyDataSetChanged")
     private val pickMedia =
@@ -116,21 +122,9 @@ class WriteReviewActivity : AppCompatActivity() {
         val placeName = intent.getStringExtra("reviewPlaceName") ?: "관광지"
 
         repeatOnStarted {
-            launch {
-                viewModel.networkState.collectLatest { state ->
-                    when (state) {
-                        is NetworkState.Loading -> {
-                        }
-
-                        is NetworkState.Success -> {
-                            finish()
-                        }
-
-                        is NetworkState.Error -> {
-                            binding.root.showSnackbar(state.msg)
-                        }
-                    }
-                }
+            supervisorScope {
+                launch { collectWriteReviewNetworkState() }
+                launch { observeConnectivity() }
             }
         }
         settingToolbar()
@@ -266,6 +260,45 @@ class WriteReviewActivity : AppCompatActivity() {
 
         } else {
             true
+        }
+    }
+
+    private suspend fun collectWriteReviewNetworkState() {
+        viewModel.networkState.collectLatest { state ->
+            when (state) {
+                is NetworkState.Loading -> {
+                }
+
+                is NetworkState.Success -> {
+                    finish()
+                }
+
+                is NetworkState.Error -> {
+                    this@WriteReviewActivity.showInfinitySnackBar(binding.root, state.msg)
+                }
+            }
+        }
+    }
+
+    private suspend fun observeConnectivity() {
+        with(binding) {
+            connectivityObserver.getFlow().collect { connectivity ->
+                when (connectivity) {
+                    ConnectivityObserver.Status.Available -> {
+                        writeReviewBtn.isEnabled = true
+                    }
+
+                    ConnectivityObserver.Status.Unavailable -> {}
+                    ConnectivityObserver.Status.Losing,
+                    ConnectivityObserver.Status.Lost -> {
+                        val msg = "${getString(R.string.text_network_is_unavailable)}\n" +
+                                "${getString(R.string.text_plz_check_network)} "
+
+                        writeReviewBtn.isEnabled = false
+                        this@WriteReviewActivity.showInfinitySnackBar(binding.root, msg)
+                    }
+                }
+            }
         }
     }
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/WriteReviewActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/home/WriteReviewActivity.kt
@@ -67,7 +67,8 @@ class WriteReviewActivity : AppCompatActivity() {
                     val path = this.toAbsolutePath(uri)
                     viewModel.setReviewImages(path!!)
                 } else {
-                    Snackbar.make(binding.root, "이미지는 최대 4장까지 첨부 가능합니다", Snackbar.LENGTH_SHORT).show()
+                    Snackbar.make(binding.root, "이미지는 최대 4장까지 첨부 가능합니다", Snackbar.LENGTH_SHORT)
+                        .show()
                 }
             }
         }
@@ -90,7 +91,8 @@ class WriteReviewActivity : AppCompatActivity() {
                         val path = this.toAbsolutePath(uri)
                         viewModel.setReviewImages(path!!)
                     } else {
-                        Snackbar.make(binding.root, "이미지는 최대 4장까지 첨부 가능합니다", Snackbar.LENGTH_SHORT).show()
+                        Snackbar.make(binding.root, "이미지는 최대 4장까지 첨부 가능합니다", Snackbar.LENGTH_SHORT)
+                            .show()
                     }
                 }
             }
@@ -144,7 +146,7 @@ class WriteReviewActivity : AppCompatActivity() {
     }
 
     private fun settingImageRVAdapter() {
-        imageRVAdapter = WriteReviewImageRVAdapter(selectedImages) {position ->
+        imageRVAdapter = WriteReviewImageRVAdapter(selectedImages) { position ->
             viewModel.deleteImage(position)
         }
         binding.writeReviewImageRv.adapter = imageRVAdapter
@@ -240,7 +242,8 @@ class WriteReviewActivity : AppCompatActivity() {
         val visitDateValue = visitDate?.let {
             formatDateValue(visitDate)
         }
-        binding.writeReviewDateEdit.text = Editable.Factory.getInstance().newEditable(visitDateValue)
+        binding.writeReviewDateEdit.text =
+            Editable.Factory.getInstance().newEditable(visitDateValue)
     }
 
     private fun checkReviewValid(): Boolean {


### PR DESCRIPTION
## #️⃣연관된 이슈

- #263 

## 📝작업 내용

- 관광지 리뷰 모아보기 네트워크 에러처리
- 관광지 리뷰 작성 네트워크 에러처리

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
- 리뷰 모아보기 네트워크 에러처리

https://github.com/user-attachments/assets/92396cd4-2c85-4387-8b96-e415b12c417e


- 리뷰 작성 네트워크 에러처리

https://github.com/user-attachments/assets/2f8d0c79-b78b-429b-8ea5-3f4678c687f2


## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  - 리뷰 모아모기에서 네트워크 연결은 됐는데 상태가 Error일 때 로그인/비로그인마다 부르는 함수가 달라서 로그인 상태를 확인하는 함수를 launch 안에서 불렀는데 코루틴 함수 안에서 이렇게 호출해도 될까요?
어디 부분인진 코멘트에 다시 달아두겠습니다 !
