### PR TITLE
[#249] 회원 탈퇴 처리 구현

### DIFF
--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/datasource/AuthDataSource.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/datasource/AuthDataSource.kt
@@ -41,6 +41,10 @@ internal class AuthDataSource @Inject constructor(
         if (refreshToken.isNotBlank()) authService.refresh("Bearer $refreshToken") else null
     }
 
+    suspend fun withdraw() = runCatching {
+        authService.withdraw()
+    }
+
     private suspend fun localLogout() {
         dataStore.updateData {
             it.copy(

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/datasource/AuthDataSource.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/datasource/AuthDataSource.kt
@@ -5,10 +5,12 @@ import androidx.datastore.core.DataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kr.tekit.lion.data.common.execute
 import kr.tekit.lion.data.database.AppSettings
 import kr.tekit.lion.data.database.dataStore
 import kr.tekit.lion.data.dto.response.SignUpResponse
 import kr.tekit.lion.data.service.AuthService
+import kr.tekit.lion.domain.exception.Result
 import okhttp3.RequestBody
 import javax.inject.Inject
 
@@ -29,20 +31,22 @@ internal class AuthDataSource @Inject constructor(
         authService.signIn(type = type, token = "Bearer $accessToken", requestBody = refreshToken)
     }
 
-    suspend fun logout(): Result<Unit> = runCatching {
+     suspend fun logout(): kotlin.Result<Unit> = runCatching{
         val accessToken = data.map { it.accessToken }.first()
         localLogout()
         authService.signOut("Bearer $accessToken")
     }
 
-    suspend fun refresh(): Result<SignUpResponse?> = runCatching {
+    suspend fun refresh(): kotlin.Result<SignUpResponse?> = runCatching{
         val refreshToken = data.map { it.refreshToken }.first()
 
         if (refreshToken.isNotBlank()) authService.refresh("Bearer $refreshToken") else null
     }
 
-    suspend fun withdraw() = runCatching {
-        authService.withdraw()
+    suspend fun withdraw(): Result<Unit> = execute{
+        val accessToken = data.map { it.accessToken }.first()
+        localLogout()
+        authService.withdraw("Bearer $accessToken")
     }
 
     private suspend fun localLogout() {

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/repository/AuthRepositoryImpl.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/repository/AuthRepositoryImpl.kt
@@ -6,6 +6,7 @@ import kr.tekit.lion.data.datasource.TokenDataSource
 import kr.tekit.lion.data.dto.request.SignInRequest
 import kr.tekit.lion.data.dto.request.toRequestBody
 import kr.tekit.lion.domain.repository.AuthRepository
+import kr.tekit.lion.domain.exception.Result
 import javax.inject.Inject
 
 internal class AuthRepositoryImpl @Inject constructor(
@@ -25,13 +26,7 @@ internal class AuthRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun logout(): Result<Unit> = authDataSource.logout()
+    override suspend fun logout(): kotlin.Result<Unit> = authDataSource.logout()
 
-    override suspend fun withdraw() = exc {
-        authDataSource.withdraw().onSuccess {
-            Result.success(Unit)
-        }.onFailure {
-            it.printStackTrace()
-        }
-    }
+    override suspend fun withdraw(): Result<Unit> = authDataSource.withdraw()
 }

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/repository/AuthRepositoryImpl.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/repository/AuthRepositoryImpl.kt
@@ -26,4 +26,12 @@ internal class AuthRepositoryImpl @Inject constructor(
     }
 
     override suspend fun logout(): Result<Unit> = authDataSource.logout()
+
+    override suspend fun withdraw() = exc {
+        authDataSource.withdraw().onSuccess {
+            Result.success(Unit)
+        }.onFailure {
+            it.printStackTrace()
+        }
+    }
 }

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/service/AuthService.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/service/AuthService.kt
@@ -29,4 +29,9 @@ internal interface AuthService {
     suspend fun refresh(
         @Header("Authorization") refreshToken: String,
     ): SignUpResponse
+
+    @GET("auth/withdrawal")
+    suspend fun withdraw(
+        @Tag authType: AuthType = AuthType.ACCESS_TOKEN
+    )
 }

--- a/DaOnGil/data/src/main/java/kr/tekit/lion/data/service/AuthService.kt
+++ b/DaOnGil/data/src/main/java/kr/tekit/lion/data/service/AuthService.kt
@@ -4,6 +4,7 @@ import kr.tekit.lion.data.dto.response.SignUpResponse
 import kr.tekit.lion.data.dto.response.signin.SignInResponse
 import okhttp3.RequestBody
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.POST
@@ -30,8 +31,8 @@ internal interface AuthService {
         @Header("Authorization") refreshToken: String,
     ): SignUpResponse
 
-    @GET("auth/withdrawal")
+    @DELETE("auth/withdrawal")
     suspend fun withdraw(
-        @Tag authType: AuthType = AuthType.ACCESS_TOKEN
+        @Header("Authorization") token: String,
     )
 }

--- a/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/repository/AuthRepository.kt
+++ b/DaOnGil/domain/src/main/java/kr/tekit/lion/domain/repository/AuthRepository.kt
@@ -1,9 +1,11 @@
 package kr.tekit.lion.domain.repository
 
 import kotlinx.coroutines.flow.Flow
+import kr.tekit.lion.domain.exception.Result
 
 interface AuthRepository {
     suspend fun signIn(type: String, accessToken: String, refreshToken: String)
-    suspend fun logout(): Result<Unit>
+    suspend fun logout(): kotlin.Result<Unit>
+    suspend fun withdraw(): Result<Unit>
     val loggedIn: Flow<Boolean>
 }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myinfo/DeleteUserActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myinfo/DeleteUserActivity.kt
@@ -2,16 +2,25 @@ package kr.tekit.lion.presentation.myinfo
 
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import com.kakao.sdk.user.UserApiClient
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.flow.collect
 import kr.tekit.lion.presentation.databinding.ActivityDeleteUserBinding
+import kr.tekit.lion.presentation.delegate.NetworkState
+import kr.tekit.lion.presentation.ext.repeatOnStarted
+import kr.tekit.lion.presentation.ext.showInfinitySnackBar
 import kr.tekit.lion.presentation.login.LoginActivity
 import kr.tekit.lion.presentation.main.dialog.ConfirmDialog
+import kr.tekit.lion.presentation.myinfo.vm.DeleteUserViewModel
 
+@AndroidEntryPoint
 class DeleteUserActivity : AppCompatActivity() {
     private val binding: ActivityDeleteUserBinding by lazy {
         ActivityDeleteUserBinding.inflate(layoutInflater)
     }
+    private val viewModel: DeleteUserViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -23,19 +32,32 @@ class DeleteUserActivity : AppCompatActivity() {
             }
 
             btnDelete.setOnClickListener {
-                val permissionDialog = ConfirmDialog(
+                val dialog = ConfirmDialog(
                     "회원 탈퇴",
                     "정말 회원을 탈퇴 하시겠습니까?",
                     "탈퇴 하기"
                 ) {
-                    UserApiClient.instance.unlink {
-
+                    viewModel.withdrawal {
+                        startActivity(Intent(this@DeleteUserActivity, LoginActivity::class.java))
+                        finish()
                     }
-                    startActivity(Intent(this@DeleteUserActivity, LoginActivity::class.java))
-                    finish()
                 }
-                permissionDialog.isCancelable = false
-                permissionDialog.show(supportFragmentManager, "PermissionDialog")
+                dialog.isCancelable = false
+                dialog.show(supportFragmentManager, "dialog")
+            }
+        }
+        repeatOnStarted {
+            viewModel.networkState.collect { state ->
+                when (state) {
+                    is NetworkState.Loading -> return@collect
+                    is NetworkState.Success -> {
+                        startActivity(Intent(this@DeleteUserActivity, LoginActivity::class.java))
+                        finish()
+                    }
+                    is NetworkState.Error -> {
+                        showInfinitySnackBar(binding.root, state.msg)
+                    }
+                }
             }
         }
     }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myinfo/vm/DeleteUserViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/myinfo/vm/DeleteUserViewModel.kt
@@ -1,0 +1,30 @@
+package kr.tekit.lion.presentation.myinfo.vm
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import kr.tekit.lion.domain.exception.onError
+import kr.tekit.lion.domain.exception.onSuccess
+import kr.tekit.lion.domain.repository.AuthRepository
+import kr.tekit.lion.presentation.delegate.NetworkErrorDelegate
+import javax.inject.Inject
+
+@HiltViewModel
+class DeleteUserViewModel @Inject constructor(
+    private val authRepository: AuthRepository
+): ViewModel() {
+
+    @Inject
+    lateinit var networkErrorDelegate: NetworkErrorDelegate
+
+    val networkState get() = networkErrorDelegate.networkState
+
+    fun withdrawal(onSuccess: () -> Unit) = viewModelScope.launch{
+        authRepository.withdraw().onSuccess {
+            onSuccess()
+        }.onError { e ->
+            networkErrorDelegate.handleNetworkError(e)
+        }
+    }
+}

--- a/DaOnGil/presentation/src/main/res/layout/fragment_home_main.xml
+++ b/DaOnGil/presentation/src/main/res/layout/fragment_home_main.xml
@@ -64,7 +64,7 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_marginStart="@dimen/margin_basic"
-                    android:layout_marginTop="40dp"
+                    android:layout_marginTop="@dimen/margin_big4"
                     android:fontFamily="@font/pretendard_medium"
                     android:text="어서오세요!"
                     android:textColor="@color/text_quaternary"

--- a/DaOnGil/presentation/src/main/res/layout/item_tourist_recommend.xml
+++ b/DaOnGil/presentation/src/main/res/layout/item_tourist_recommend.xml
@@ -72,7 +72,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="@dimen/margin_big2"
                 android:layout_marginEnd="30dp"
-                android:layout_marginBottom="@dimen/margin_big1"
+                android:layout_marginBottom="@dimen/margin_big2"
                 android:ellipsize="end"
                 android:fontFamily="@font/pretendard_regular"
                 android:maxLines="1"


### PR DESCRIPTION
## #️⃣연관된 이슈

- #249 
## 📝작업 내용
회원 탈퇴 API 구현 완료했습니다.

## PR 발행 전 체크 리스트

- [ ] 발행자 확인
- [ ] 프로젝트 설정 확인
- [ ] 라벨 확인

## 스크린샷 (선택)


## 💬리뷰 요구사항(선택)
- 기존 로그아웃 API와 동일하게 회원 탈퇴시 DataStore에 저장된 토큰 정보 제거까지 확인했습니다.
- 기존 회원 판별을 위해 새로 가입하는 유저에 한해서 관심 유형 API 호출 후 true로된 정보가 있다면 
기존 유저로 판별, 없다면 새로 가입하는 유저로 판단하여 관심 유형 선택 화면을 보여줬는데 
탈퇴후 재가입하면 이 화면이 잘뜨네용 요 부분도 그대로 진행해도 될 것 같습니다 !
