### PR TITLE
[#279] 최초 유저 판별 데이터 리딩시 앱 크래시 수정

### DIFF
--- a/DaOnGil/app/build.gradle.kts
+++ b/DaOnGil/app/build.gradle.kts
@@ -1,0 +1,90 @@
+import java.util.Properties
+
+plugins {
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.jetbrains.kotlin.android)
+    alias(libs.plugins.kapt)
+    alias(libs.plugins.hilt)
+    alias(libs.plugins.google.services)
+    alias(libs.plugins.firebase.crashlytics)
+}
+
+val properties = Properties()
+properties.load(project.rootProject.file("local.properties").inputStream())
+val kakaoApiKey = properties.getProperty("kakao_api_key") ?: ""
+val kakaoNativeKey = properties.getProperty("kakao_native_key") ?: ""
+val naverMapId = properties.getProperty("naver_map_id") ?: ""
+val naverClientId = properties.getProperty("naver_client_id") ?: ""
+val naverClientSecret = properties.getProperty("naver_client_secret") ?: ""
+val naverClientName = properties.getProperty("naver_client_name") ?: ""
+
+android {
+
+    namespace = "kr.tekit.lion.daongil_cleanarchitecture"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "kr.tekit.lion.daongil_cleanarchitecture"
+        minSdk = 26
+        //noinspection OldTargetApi,EditedTargetSdkVersion
+        targetSdk = 34
+        versionCode = 3
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        vectorDrawables {
+            useSupportLibrary = true
+        }
+
+        buildConfigField("String", "KAKAO_API_KEY", "\"$kakaoApiKey\"")
+        buildConfigField("String", "NAVER_CLIENT_ID", "\"$naverClientId\"")
+        buildConfigField("String", "NAVER_CLIENT_SECRET", "\"$naverClientSecret\"")
+        buildConfigField("String", "NAVER_CLIENT_NAME", "\"$naverClientName\"")
+        buildConfigField("String", "KAKAO_NATIVE_KEY", "\"$kakaoNativeKey\"")
+        manifestPlaceholders["KAKAO_NATIVE_KEY"] = kakaoNativeKey
+        manifestPlaceholders["NAVER_MAP_ID"] = naverMapId
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = true
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_17.toString()
+    }
+    kapt{
+        correctErrorTypes = true
+    }
+    buildFeatures {
+        buildConfig = true
+    }
+}
+
+dependencies {
+    implementation(project(":data"))
+    implementation(project(":domain"))
+    implementation(project(":presentation"))
+
+    implementation(libs.androidx.core.ktx)
+    testImplementation(libs.junit)
+    androidTestImplementation(libs.androidx.junit)
+    androidTestImplementation(libs.androidx.espresso.core)
+
+    implementation(libs.hilt)
+    kapt(libs.hilt.compiler)
+
+    implementation(libs.kakao.user)
+    implementation(libs.navercorp)
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.analytics)
+    implementation(libs.firebase.crashlytics)
+}

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/HomeMainFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/main/fragment/HomeMainFragment.kt
@@ -36,6 +36,7 @@ import com.google.android.gms.location.Priority
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
@@ -105,14 +106,7 @@ class HomeMainFragment : Fragment(R.layout.fragment_home_main) {
                 launch { collectAppTheme() }
                 launch { collectNetworkState(binding) }
                 launch { observeConnectivity(binding) }
-                launch {
-                    viewModel.userActivationState.collect {
-                        if (it) {
-                            if (isDarkTheme(resources.configuration)) showThemeGuideDialog()
-                            else showThemeSettingDialog()
-                        }
-                    }
-                }
+                launch { observeUserActivation() }
             }
         }
 
@@ -547,6 +541,15 @@ class HomeMainFragment : Fragment(R.layout.fragment_home_main) {
                         homeErrorTv.text = state.msg
                     }
                 }
+            }
+        }
+    }
+
+    private suspend fun observeUserActivation() {
+        viewModel.userActivationState.collect{ isFirstUser ->
+            if (isFirstUser){
+                if (isDarkTheme(resources.configuration)) showThemeGuideDialog()
+                else showThemeSettingDialog()
             }
         }
     }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/splash/SplashActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/splash/SplashActivity.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.delay
 import kr.tekit.lion.presentation.R
 import kr.tekit.lion.presentation.databinding.ActivitySplashBinding
 import kr.tekit.lion.presentation.ext.repeatOnStarted
+import kr.tekit.lion.presentation.ext.showInfinitySnackBar
 import kr.tekit.lion.presentation.login.OnBoardingActivity
 import kr.tekit.lion.presentation.main.MainActivity
 import kr.tekit.lion.presentation.splash.vm.SplashViewModel
@@ -28,7 +29,7 @@ class SplashActivity : AppCompatActivity() {
         setContentView(binding.root)
 
         val videoPath = "android.resource://" + packageName + "/" + R.raw.splash_video
-        with(binding.splashVideoView){
+        with(binding.splashVideoView) {
 
             setVideoURI(Uri.parse(videoPath))
 
@@ -74,12 +75,9 @@ class SplashActivity : AppCompatActivity() {
             }
 
             repeatOnStarted {
-                viewModel.err.collect{
+                viewModel.errorState.collect {
                     if (it) {
-                        viewModel.whenUserActivationIsFirst {
-                            startActivity(Intent(this@SplashActivity, OnBoardingActivity::class.java))
-                            finish()
-                        }
+                        showInfinitySnackBar(binding.root, getString(R.string.text_common_error))
                     }
                 }
             }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/splash/vm/SplashViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/splash/vm/SplashViewModel.kt
@@ -3,12 +3,10 @@ package kr.tekit.lion.presentation.splash.vm
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.shareIn
-import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.launch
 import kr.tekit.lion.domain.repository.ActivationRepository
 import kr.tekit.lion.domain.usecase.areacode.InitAreaCodeInfoUseCase
 import kr.tekit.lion.domain.usecase.base.onError
@@ -21,8 +19,8 @@ class SplashViewModel @Inject constructor(
     private val initAreaCodeInfoUseCase: InitAreaCodeInfoUseCase,
 ): ViewModel() {
 
-    private val _err = MutableSharedFlow<Boolean>()
-    val err = _err.asSharedFlow()
+    private val _errorState = MutableStateFlow(false)
+    val errorState get() = _errorState.asStateFlow()
 
     val userActivationState = activationRepository.userActivation.shareIn(
         scope = viewModelScope,
@@ -33,9 +31,7 @@ class SplashViewModel @Inject constructor(
         initAreaCodeInfoUseCase().onSuccess {
             onComplete()
         }.onError {
-            viewModelScope.launch {
-                _err.emit(true)
-            }
+            _errorState.value = true
         }
     }
 }

--- a/DaOnGil/presentation/src/main/res/layout/activity_keyword_search.xml
+++ b/DaOnGil/presentation/src/main/res/layout/activity_keyword_search.xml
@@ -27,7 +27,7 @@
     <com.google.android.material.textfield.TextInputLayout
         android:id="@+id/search_bar"
         android:layout_width="match_parent"
-        android:layout_height="55dp"
+        android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_big3"
         android:layout_marginEnd="@dimen/margin_big4"
         app:hintEnabled="false"

--- a/DaOnGil/presentation/src/main/res/values/strings.xml
+++ b/DaOnGil/presentation/src/main/res/values/strings.xml
@@ -411,5 +411,5 @@
     <string name="text_my_review_img">후기 이미지 두 번 탭하면 이미지 보기 화면으로 이동합니다</string>
     <string name="text_my_review_modify_move">후기 수정하기</string>
     <string name="text_my_review_delete">후기 삭제하기</string>
-
+    <string name="text_common_error">오류가 발갱했습니다. 앱 종료 후 다시 시도해주세요.</string>
 </resources>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #279 

## 📝작업 내용

계속 앱 크래시키던 놈 잡았습니다. 😡

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/571886f8-9180-4df8-acef-b86fe8b7bb69)

## 💬리뷰 요구사항(선택)

정확한 원인은 파악을 못해서 GPT 통해서 추측해봤습니다.
```
NullPointerException 원인: 에러 메시지에서 MutableSharedFlow.tryEmit() 
호출 시점에 MutableSharedFlow 객체가 null이라는 사실을 확인할 수 있습니다. 
즉, _userActivationState가 아직 초기화되지 않은 상태에서 tryEmit을 호출했기 때문에 발생한 것입니다. 
이 경우, tryEmit이 호출되기 전에 MutableSharedFlow가 적절히 초기화되어야 합니다.
```
라고 하길래 shareIn 을 사용해서 구독자가 있을 때 만 값을 방출하도록 하고
구독자가 없는 경우 5000ms 동안 값을 유지하도록 수정했습니다. 

shareInd이 Flow를 SharedFlow로 변환하는 함수는 맞지만
MutableSharedFlow와는 다르게 shareIn은 값을 미리 방출하거나 
구독자가 없을 때 문제를 일으키지 않기 때문에 NullPointerException을 방지할 수 있다고 합니다.