### PR TITLE
[#276] 일정 수정화면 접근성 개선

### DIFF
--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/ModifyNamePeriodFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/ModifyNamePeriodFragment.kt
@@ -13,6 +13,7 @@ import com.google.android.material.textfield.TextInputLayout
 import dagger.hilt.android.AndroidEntryPoint
 import kr.tekit.lion.presentation.R
 import kr.tekit.lion.presentation.databinding.FragmentModifyNamePeriodBinding
+import kr.tekit.lion.presentation.ext.setAccessibilityText
 import kr.tekit.lion.presentation.ext.showSnackbar
 import kr.tekit.lion.presentation.scheduleform.FormDateFormat
 import kr.tekit.lion.presentation.scheduleform.model.OriginalScheduleInfo
@@ -75,7 +76,10 @@ class ModifyNamePeriodFragment : Fragment(R.layout.fragment_modify_name_period) 
         }
         viewModel.endDate.observe(viewLifecycleOwner) {
             val pickedDates = viewModel.formatPickedDates(FormDateFormat.YYYY_MM_DD_E)
-            binding.buttonModifyNpfSetPeriod.text = pickedDates
+            binding.buttonModifyNpfSetPeriod.apply {
+                text = pickedDates
+                setAccessibilityText(viewModel.getSchedulePeriodAccessibilityText())
+            }
         }
     }
 

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/ModifyScheduleConfirmFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/ModifyScheduleConfirmFragment.kt
@@ -12,6 +12,7 @@ import kr.tekit.lion.domain.model.scheduleform.DailySchedule
 import kr.tekit.lion.presentation.R
 import kr.tekit.lion.presentation.databinding.FragmentModifyScheduleConfirmBinding
 import kr.tekit.lion.presentation.delegate.NetworkState
+import kr.tekit.lion.presentation.ext.setAccessibilityText
 import kr.tekit.lion.presentation.ext.showSnackbar
 import kr.tekit.lion.presentation.schedule.ResultCode
 import kr.tekit.lion.presentation.scheduleform.FormDateFormat
@@ -71,7 +72,10 @@ class ModifyScheduleConfirmFragment : Fragment(R.layout.fragment_modify_schedule
         val period = viewModel.formatPickedDates(FormDateFormat.YYYY_MM_DD)
         binding.apply {
             textMcfTitle.text = getString(R.string.text_selected_title, title)
-            textMcfDate.text = getString(R.string.text_selected_period, period)
+            textMcfDate.apply {
+                text = getString(R.string.text_selected_period, period)
+                setAccessibilityText(viewModel.getSchedulePeriodAccessibilityText())
+            }
             buttonModifyFormSubmit.setOnClickListener {
                 submitPlan(it)
             }

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/ModifyScheduleDetailsFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/fragment/ModifyScheduleDetailsFragment.kt
@@ -2,7 +2,6 @@ package kr.tekit.lion.presentation.scheduleform.fragment
 
 import android.content.Intent
 import android.os.Bundle
-import android.util.Log
 import androidx.fragment.app.Fragment
 import android.view.View
 import androidx.fragment.app.activityViewModels
@@ -11,6 +10,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kr.tekit.lion.domain.model.scheduleform.DailySchedule
 import kr.tekit.lion.presentation.R
 import kr.tekit.lion.presentation.databinding.FragmentModifyScheduleDetailsBinding
+import kr.tekit.lion.presentation.ext.setAccessibilityText
 import kr.tekit.lion.presentation.home.DetailActivity
 import kr.tekit.lion.presentation.scheduleform.FormDateFormat
 import kr.tekit.lion.presentation.scheduleform.adapter.FormScheduleAdapter
@@ -41,7 +41,10 @@ class ModifyScheduleDetailsFragment : Fragment(R.layout.fragment_modify_schedule
             val title = viewModel.getScheduleTitle()
             textModifyDetailTitle.text = getString(R.string.text_selected_title, title)
             val period = viewModel.formatPickedDates(FormDateFormat.YYYY_MM_DD)
-            textModifyDetailDate.text = getString(R.string.text_selected_period, period)
+            textModifyDetailDate.apply {
+                text = getString(R.string.text_selected_period, period)
+                setAccessibilityText(viewModel.getSchedulePeriodAccessibilityText())
+            }
 
             buttonModiyDetailNextStep.setOnClickListener { view ->
                 val action =

--- a/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/vm/ModifyScheduleFormViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/tekit/lion/presentation/scheduleform/vm/ModifyScheduleFormViewModel.kt
@@ -25,6 +25,7 @@ import kr.tekit.lion.presentation.delegate.NetworkErrorDelegate
 import kr.tekit.lion.presentation.delegate.NetworkState
 import kr.tekit.lion.presentation.ext.addDays
 import kr.tekit.lion.presentation.ext.calculateDaysUntilEndDate
+import kr.tekit.lion.presentation.ext.convertPeriodToDate
 import kr.tekit.lion.presentation.ext.convertStringToDate
 import kr.tekit.lion.presentation.ext.formatDateValue
 import kr.tekit.lion.presentation.scheduleform.FormDateFormat
@@ -244,6 +245,13 @@ class ModifyScheduleFormViewModel @Inject constructor(
         }
 
         _schedule.value = updatedSchedule.toList()
+    }
+
+    fun getSchedulePeriodAccessibilityText(): String {
+        val startDate = _startDate.value ?: Date()
+        val endDate = _endDate.value ?: Date()
+
+        return startDate.convertPeriodToDate(endDate)
     }
 
     fun getPlaceSearchResult(isNewRequest: Boolean) {

--- a/DaOnGil/presentation/src/main/res/layout/fragment_modify_name_period.xml
+++ b/DaOnGil/presentation/src/main/res/layout/fragment_modify_name_period.xml
@@ -16,6 +16,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:navigationContentDescription="@string/text_back_button"
         app:navigationIcon="@drawable/back_icon">
 
         <TextView

--- a/DaOnGil/presentation/src/main/res/layout/fragment_modify_schedule_confirm.xml
+++ b/DaOnGil/presentation/src/main/res/layout/fragment_modify_schedule_confirm.xml
@@ -16,6 +16,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
+        app:navigationContentDescription="@string/text_back_button"
         app:navigationIcon="@drawable/back_icon">
 
         <TextView

--- a/DaOnGil/presentation/src/main/res/layout/fragment_modify_schedule_details.xml
+++ b/DaOnGil/presentation/src/main/res/layout/fragment_modify_schedule_details.xml
@@ -19,6 +19,7 @@
             android:layout_height="wrap_content"
             android:background="@color/navi_background"
             android:minHeight="?attr/actionBarSize"
+            app:navigationContentDescription="@string/text_back_button"
             app:navigationIcon="@drawable/back_icon">
 
             <TextView


### PR DESCRIPTION
## #️⃣연관된 이슈

- #276 

## 📝작업 내용

- 기존 일정을 수정하는 화면에서 필요한 접근성 개선했습니다. 

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
- 아래 링크와 동일하게 읽어주도록 처리 했습니다
(https://github.com/Journey-Together/DaOnGil_CleanArchitecture/pull/275)

## 💬리뷰 요구사항(선택)

