### PR TITLE
[#284]  응급지원 네트워크 에러 처리

### DIFF
--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/emergency/vm/PharmacyMapViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/emergency/vm/PharmacyMapViewModel.kt
@@ -29,11 +29,13 @@ class PharmacyMapViewModel @Inject constructor(
     private val _pharmacyMapInfo = MutableLiveData<List<PharmacyMapInfo>>()
     val pharmacyMapInfo : LiveData<List<PharmacyMapInfo>> = _pharmacyMapInfo
 
+    val networkState get() = networkErrorDelegate.networkState
+
     fun getPharmacyMapInfo(Q0: String?, Q1: String?) =
         viewModelScope.launch {
-            val areaDetail = if (Q0 == "세종특별자치시") null else Q1
             pharmacyRepository.getPharmacy(Q0, Q1).onSuccess {
                 _pharmacyMapInfo.value = it
+                networkErrorDelegate.handleNetworkSuccess()
             }.onError {
                 networkErrorDelegate.handleNetworkError(it)
             }
@@ -42,7 +44,10 @@ class PharmacyMapViewModel @Inject constructor(
         naverMapRepository.getReverseGeoCode(coords).onSuccess {
             if(it.code == 0){
                 _area.value = "${it.results[0].area} ${it.results[0].areaDetail}"
+            } else {
+                _area.value = "서울특별시 중구"
             }
+            networkErrorDelegate.handleNetworkSuccess()
         }.onError {
             networkErrorDelegate.handleNetworkError(it)
         }

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/main/fragment/EmergencyMainFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/main/fragment/EmergencyMainFragment.kt
@@ -4,17 +4,28 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.View
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
 import kr.techit.lion.presentation.R
 import kr.techit.lion.presentation.databinding.FragmentEmergencyMainBinding
 import kr.techit.lion.presentation.emergency.EmergencyMapActivity
 import kr.techit.lion.presentation.emergency.PharmacyMapActivity
+import kr.techit.lion.presentation.emergency.fragment.EmergencyAreaDialog
+import kr.techit.lion.presentation.ext.repeatOnViewStarted
+import kr.techit.lion.presentation.observer.ConnectivityObserver
+import kr.techit.lion.presentation.observer.NetworkConnectivityObserver
 
 class EmergencyMainFragment : Fragment(R.layout.fragment_emergency_main) {
+
+    private val connectivityObserver: ConnectivityObserver by lazy {
+        NetworkConnectivityObserver.getInstance(requireActivity())
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         val binding = FragmentEmergencyMainBinding.bind(view)
+
 
         binding.emrAedCard.setOnClickListener {
             val intent = Intent(requireActivity(), EmergencyMapActivity::class.java)
@@ -24,6 +35,36 @@ class EmergencyMainFragment : Fragment(R.layout.fragment_emergency_main) {
         binding.pharmacyCard.setOnClickListener {
             val intent = Intent(requireActivity(), PharmacyMapActivity::class.java)
             startActivity(intent)
+        }
+
+        repeatOnViewStarted {
+            supervisorScope {
+                launch { observeConnectivity(binding) }
+            }
+        }
+    }
+
+    private suspend fun observeConnectivity(binding: FragmentEmergencyMainBinding) {
+        with(binding){
+            connectivityObserver.getFlow().collect { connectivity ->
+                when(connectivity){
+                    ConnectivityObserver.Status.Available -> {
+                        emergencyMainErrorLayout.visibility = View.GONE
+                        emergencyMainProgressBar.visibility = View.GONE
+                        emergencyMainLayout.visibility = View.VISIBLE
+                    }
+                    ConnectivityObserver.Status.Unavailable,
+                    ConnectivityObserver.Status.Losing,
+                    ConnectivityObserver.Status.Lost -> {
+                        emergencyMainErrorLayout.visibility = View.VISIBLE
+                        emergencyMainProgressBar.visibility = View.GONE
+                        emergencyMainLayout.visibility = View.GONE
+                        val msg = "${getString(R.string.text_network_is_unavailable)}\n" +
+                                "${getString(R.string.text_plz_check_network)} "
+                        emergencyMainErrorMsg.text = msg
+                    }
+                }
+            }
         }
     }
 }

--- a/DaOnGil/presentation/src/main/res/layout/activity_emergency_map.xml
+++ b/DaOnGil/presentation/src/main/res/layout/activity_emergency_map.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -32,15 +31,57 @@
             android:layout_height="wrap_content"
             app:indicatorColor="@color/primary"
             android:progress="20"
+            android:visibility="gone"
             app:trackColor="@color/background_color"/>
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <FrameLayout
+    <LinearLayout
+        android:id="@+id/emergencyMapErrorLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_gravity="center"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/toolbarSchedule"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <ImageView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:srcCompat="@drawable/onboarding_clover" />
+
+        <TextView
+            android:id="@+id/emergencyMapErrorMsg"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_big4"
+            android:lineSpacingMultiplier="1.2"
+            android:fontFamily="@font/cafe24_oneprettynight"
+            android:gravity="center"
+            android:text="TextView"
+            android:textSize="@dimen/font_big1" />
+    </LinearLayout>
+
+    <FrameLayout
+        android:id="@+id/emergencyMapLayout"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
+        <ProgressBar
+            android:id="@+id/emergencyMapErrorProgressBar"
+            android:layout_width="150dp"
+            android:layout_height="150dp"
+            android:layout_gravity="center"
+            android:visibility="gone"
+            android:indeterminateDrawable="@drawable/rotate_progress_bar"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/toolbarSchedule"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
 
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/emergencyMapAreaButton"

--- a/DaOnGil/presentation/src/main/res/layout/activity_pharmacy_map.xml
+++ b/DaOnGil/presentation/src/main/res/layout/activity_pharmacy_map.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -36,11 +35,52 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
+    <LinearLayout
+        android:id="@+id/pharmacyMapErrorLayout"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:layout_gravity="center"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/toolbarSchedule"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent">
+
+        <ImageView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:srcCompat="@drawable/onboarding_clover" />
+
+        <TextView
+            android:id="@+id/pharmacyMapErrorMsg"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_big4"
+            android:lineSpacingMultiplier="1.2"
+            android:fontFamily="@font/cafe24_oneprettynight"
+            android:gravity="center"
+            android:text="TextView"
+            android:textSize="@dimen/font_big1" />
+    </LinearLayout>
+
     <FrameLayout
+        android:id="@+id/pharmacyMapLayout"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
+        <ProgressBar
+            android:id="@+id/pharmacyMapErrorProgressBar"
+            android:layout_width="150dp"
+            android:layout_height="150dp"
+            android:layout_gravity="center"
+            android:visibility="gone"
+            android:indeterminateDrawable="@drawable/rotate_progress_bar"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/toolbarSchedule"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent" />
 
         <com.google.android.material.card.MaterialCardView
             android:id="@+id/pharamcyMapAreaButton"

--- a/DaOnGil/presentation/src/main/res/layout/fragment_emergency_main.xml
+++ b/DaOnGil/presentation/src/main/res/layout/fragment_emergency_main.xml
@@ -25,154 +25,208 @@
 
     </com.google.android.material.appbar.MaterialToolbar>
 
+
     <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="match_parent">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:padding="7dp"
-            tools:context=".presentation.main.fragment.EmergencyMainFragment">
+            android:layout_gravity="center"
+            android:orientation="vertical">
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="29dp"
-                android:fontFamily="@font/pretendard_bold"
-                android:paddingStart="17dp"
-                android:text="@string/text_emergency_main"
-                android:textColor="@color/text_secondary"
-                android:textSize="24dp" />
+            <ProgressBar
+                android:id="@+id/emergencyMainProgressBar"
+                android:layout_width="150dp"
+                android:layout_height="150dp"
+                android:layout_gravity="center"
+                android:indeterminateDrawable="@drawable/rotate_progress_bar"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/toolbarSchedule"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                android:visibility="gone"/>
 
-            <TextView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="@dimen/margin_big4"
-                android:fontFamily="@font/pretendard_regular"
-                android:paddingStart="17dp"
-                android:text="@string/text_emergency_second"
-                android:textColor="@color/text_secondary"
-                android:textSize="@dimen/font_big3" />
-
-            <com.google.android.material.card.MaterialCardView
-                android:id="@+id/emrAedCard"
+            <LinearLayout
+                android:id="@+id/emergencyMainErrorLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginLeft="17dp"
-                android:layout_marginTop="@dimen/margin_big1"
-                android:layout_marginRight="17dp"
-                android:backgroundTint="@color/item_background"
-                app:cardCornerRadius="10dp"
-                app:cardElevation="15dp"
-                app:strokeColor="@color/item_background">
+                android:orientation="vertical"
+                android:layout_gravity="center"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/toolbarSchedule"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintEnd_toEndOf="parent">
 
-                <LinearLayout
+                <ImageView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical">
+                    app:srcCompat="@drawable/onboarding_clover" />
 
-                    <ImageView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:layout_marginTop="@dimen/margin_big2"
-                        android:src="@drawable/emer_aed_main_icon" />
+                <TextView
+                    android:id="@+id/emergencyMainErrorMsg"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_big4"
+                    android:lineSpacingMultiplier="1.2"
+                    android:fontFamily="@font/cafe24_oneprettynight"
+                    android:gravity="center"
+                    android:text="TextView"
+                    android:textSize="@dimen/font_big1" />
+            </LinearLayout>
 
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:fontFamily="@font/pretendard_medium"
-                        android:text="@string/text_emergency_aed"
-                        android:textColor="@color/text_secondary"
-                        android:textSize="22dp" />
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:layout_marginTop="@dimen/margin_small1"
-                        android:fontFamily="@font/pretendard_regular"
-                        android:text="@string/text_emergency_aed_first"
-                        android:textColor="@color/text_tertiary"
-                        android:textSize="@dimen/font_small1" />
-
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:layout_marginTop="@dimen/margin_small2"
-                        android:layout_marginBottom="@dimen/margin_basic"
-                        android:fontFamily="@font/pretendard_regular"
-                        android:text="@string/text_emergency_aed_second"
-                        android:textColor="@color/text_tertiary"
-                        android:textSize="@dimen/font_small1" />
-
-                </LinearLayout>
-            </com.google.android.material.card.MaterialCardView>
-
-            <com.google.android.material.card.MaterialCardView
-                android:id="@+id/pharmacyCard"
+            <LinearLayout
+                android:id="@+id/emergencyMainLayout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginLeft="17dp"
-                android:layout_marginTop="@dimen/margin_big2"
-                android:layout_marginRight="17dp"
-                android:layout_marginBottom="30dp"
-                android:backgroundTint="@color/item_background"
-                app:cardCornerRadius="10dp"
-                app:cardElevation="15dp"
-                app:strokeColor="@color/item_background">
+                android:orientation="vertical"
+                android:padding="7dp"
+                android:visibility="gone"
+                tools:context=".presentation.main.fragment.EmergencyMainFragment">
 
-                <LinearLayout
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="29dp"
+                    android:fontFamily="@font/pretendard_bold"
+                    android:paddingStart="17dp"
+                    android:text="@string/text_emergency_main"
+                    android:textColor="@color/text_secondary"
+                    android:textSize="24dp" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/margin_big4"
+                    android:fontFamily="@font/pretendard_regular"
+                    android:paddingStart="17dp"
+                    android:text="@string/text_emergency_second"
+                    android:textColor="@color/text_secondary"
+                    android:textSize="@dimen/font_big3" />
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/emrAedCard"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical">
+                    android:layout_marginLeft="17dp"
+                    android:layout_marginTop="@dimen/margin_big1"
+                    android:layout_marginRight="17dp"
+                    android:backgroundTint="@color/item_background"
+                    app:cardCornerRadius="10dp"
+                    app:cardElevation="15dp"
+                    app:strokeColor="@color/item_background">
 
-                    <ImageView
-                        android:layout_width="wrap_content"
+                    <LinearLayout
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:layout_marginTop="@dimen/margin_big2"
-                        android:src="@drawable/pharmacy_main_icon" />
+                        android:orientation="vertical">
 
-                    <TextView
-                        android:layout_width="wrap_content"
+                        <ImageView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center"
+                            android:layout_marginTop="@dimen/margin_big2"
+                            android:src="@drawable/emer_aed_main_icon" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center"
+                            android:fontFamily="@font/pretendard_medium"
+                            android:text="@string/text_emergency_aed"
+                            android:textColor="@color/text_secondary"
+                            android:textSize="22dp" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center"
+                            android:layout_marginTop="@dimen/margin_small1"
+                            android:fontFamily="@font/pretendard_regular"
+                            android:text="@string/text_emergency_aed_first"
+                            android:textColor="@color/text_tertiary"
+                            android:textSize="@dimen/font_small1" />
+
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center"
+                            android:layout_marginTop="@dimen/margin_small2"
+                            android:layout_marginBottom="@dimen/margin_basic"
+                            android:fontFamily="@font/pretendard_regular"
+                            android:text="@string/text_emergency_aed_second"
+                            android:textColor="@color/text_tertiary"
+                            android:textSize="@dimen/font_small1" />
+
+                    </LinearLayout>
+                </com.google.android.material.card.MaterialCardView>
+
+                <com.google.android.material.card.MaterialCardView
+                    android:id="@+id/pharmacyCard"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginLeft="17dp"
+                    android:layout_marginTop="@dimen/margin_big2"
+                    android:layout_marginRight="17dp"
+                    android:layout_marginBottom="30dp"
+                    android:backgroundTint="@color/item_background"
+                    app:cardCornerRadius="10dp"
+                    app:cardElevation="15dp"
+                    app:strokeColor="@color/item_background">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:fontFamily="@font/pretendard_medium"
-                        android:text="@string/text_emergency_pharmacy"
-                        android:textColor="@color/text_secondary"
-                        android:textSize="22dp" />
+                        android:orientation="vertical">
 
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:layout_marginTop="@dimen/margin_small1"
-                        android:fontFamily="@font/pretendard_regular"
-                        android:text="@string/text_emergency_pharmacy_first"
-                        android:textColor="@color/text_tertiary"
-                        android:textSize="@dimen/font_small1" />
+                        <ImageView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center"
+                            android:layout_marginTop="@dimen/margin_big2"
+                            android:src="@drawable/pharmacy_main_icon" />
 
-                    <TextView
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_gravity="center"
-                        android:layout_marginTop="@dimen/margin_small2"
-                        android:layout_marginBottom="@dimen/margin_basic"
-                        android:fontFamily="@font/pretendard_regular"
-                        android:text="@string/text_emergency_pharmacy_second"
-                        android:textColor="@color/text_tertiary"
-                        android:textSize="@dimen/font_small1" />
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center"
+                            android:fontFamily="@font/pretendard_medium"
+                            android:text="@string/text_emergency_pharmacy"
+                            android:textColor="@color/text_secondary"
+                            android:textSize="22dp" />
 
-                </LinearLayout>
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center"
+                            android:layout_marginTop="@dimen/margin_small1"
+                            android:fontFamily="@font/pretendard_regular"
+                            android:text="@string/text_emergency_pharmacy_first"
+                            android:textColor="@color/text_tertiary"
+                            android:textSize="@dimen/font_small1" />
 
-            </com.google.android.material.card.MaterialCardView>
+                        <TextView
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_gravity="center"
+                            android:layout_marginTop="@dimen/margin_small2"
+                            android:layout_marginBottom="@dimen/margin_basic"
+                            android:fontFamily="@font/pretendard_regular"
+                            android:text="@string/text_emergency_pharmacy_second"
+                            android:textColor="@color/text_tertiary"
+                            android:textSize="@dimen/font_small1" />
+
+                    </LinearLayout>
+
+                </com.google.android.material.card.MaterialCardView>
+
+            </LinearLayout>
 
         </LinearLayout>
+
+
     </ScrollView>
 
 </LinearLayout>

--- a/DaOnGil/presentation/src/main/res/values/strings.xml
+++ b/DaOnGil/presentation/src/main/res/values/strings.xml
@@ -143,7 +143,8 @@
     <string name="text_browse_public_schedule">공개 일정 둘러보기</string>
 
     <string name="title_emergency_area_dialog">다른 지역 정보가 궁금하신가요?</string>
-    <string name="subtitle_emergency_area_dialog">내가 여행하고 싶은 지역으로 설정을 변경해보세요</string>
+    <string name="subtitle_emergency_area_dialog">내가 여행하고 싶은 지역으로\n 시도와 시군구 모두 선택해주세요</string>
+    <string name="content_emergency_area_dialog">시도와 시군구 모두 선택해주세요</string>
     <string name="text_relation">관계</string>
     <string name="text_birth">생년월일</string>
     <string name="text_plz_enter_nickname">닉네임을 입력해주세요</string>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #284 

## 📝작업 내용

- 응급실/제세동기 지도 화면 에러 처리
- 약국 지도 화면 에러 처리
- 응급 지원 지역 설정 다이얼로그 문구 수정
- 응급 메인 화면 에러 처리
- 외국일 경우 서울특별시 중구로 처리

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
https://github.com/user-attachments/assets/33404210-2771-4949-91a1-d0e512d4d292

약국 부분도 똑같아서 따로 첨부하지는 않겠씁니다!

## 💬리뷰 요구사항(선택)

- 응급 지원 부분 에러처리 완료했씁니다...! 특별히 다른 건 없어서 금방 머지하겠씁니다...!!
