### PR TITLE
#292 네트워크 상태 옵저빙 클래스 수정

### DIFF
--- a/DaOnGil/app/src/main/java/kr/techit/lion/daongil_cleanarchitecture/App.kt
+++ b/DaOnGil/app/src/main/java/kr/techit/lion/daongil_cleanarchitecture/App.kt
@@ -1,9 +1,7 @@
 package kr.techit.lion.daongil_cleanarchitecture
 
 import android.app.Application
-import android.util.Log
 import com.kakao.sdk.common.KakaoSdk
-import com.kakao.sdk.common.util.Utility
 import com.navercorp.nid.NaverIdLoginSDK
 import dagger.hilt.android.HiltAndroidApp
 

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/bookmark/BookmarkActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/bookmark/BookmarkActivity.kt
@@ -31,7 +31,7 @@ class BookmarkActivity : AppCompatActivity() {
     }
     private val viewModel: BookmarkViewModel by viewModels()
     private val connectivityObserver: ConnectivityObserver by lazy {
-        NetworkConnectivityObserver.getInstance(this)
+        NetworkConnectivityObserver(applicationContext)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/concerntype/fragment/ConcernTypeFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/concerntype/fragment/ConcernTypeFragment.kt
@@ -24,7 +24,7 @@ class ConcernTypeFragment : Fragment(R.layout.fragment_concern_type) {
 
     private val viewModel: ConcernTypeViewModel by activityViewModels()
     private val connectivityObserver: ConnectivityObserver by lazy {
-        NetworkConnectivityObserver.getInstance(requireContext())
+        NetworkConnectivityObserver(requireContext().applicationContext)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/concerntype/fragment/ConcernTypeModifyFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/concerntype/fragment/ConcernTypeModifyFragment.kt
@@ -24,7 +24,7 @@ class ConcernTypeModifyFragment : Fragment(R.layout.fragment_concern_type_modify
 
     private val viewModel: ConcernTypeViewModel by activityViewModels()
     private val connectivityObserver: ConnectivityObserver by lazy {
-        NetworkConnectivityObserver.getInstance(requireContext())
+        NetworkConnectivityObserver(requireContext().applicationContext)
     }
     private val selectedConcernType = mutableSetOf<Int>()
 

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/emergency/fragment/EmergencyAreaDialog.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/emergency/fragment/EmergencyAreaDialog.kt
@@ -14,9 +14,7 @@ import kr.techit.lion.presentation.databinding.DialogEmergencyAreaBinding
 import kr.techit.lion.presentation.emergency.vm.EmergencyMapViewModel
 
 @AndroidEntryPoint
-class EmergencyAreaDialog(
-
-) : DialogFragment(R.layout.dialog_emergency_area) {
+class EmergencyAreaDialog : DialogFragment(R.layout.dialog_emergency_area) {
 
     private val viewModel: EmergencyMapViewModel by activityViewModels()
 

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/emergency/fragment/PharmacyAreaDialog.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/emergency/fragment/PharmacyAreaDialog.kt
@@ -14,9 +14,7 @@ import kr.techit.lion.presentation.databinding.DialogEmergencyAreaBinding
 import kr.techit.lion.presentation.emergency.vm.PharmacyMapViewModel
 
 @AndroidEntryPoint
-class PharmacyAreaDialog(
-
-) : DialogFragment(R.layout.dialog_emergency_area) {
+class PharmacyAreaDialog: DialogFragment(R.layout.dialog_emergency_area) {
     private val viewModel: PharmacyMapViewModel by activityViewModels()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/emergency/vm/EmergencyInfoViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/emergency/vm/EmergencyInfoViewModel.kt
@@ -18,7 +18,6 @@ class EmergencyInfoViewModel @Inject constructor(
     private val emergencyRepository: EmergencyRepository
 ): ViewModel() {
 
-
     @Inject
     lateinit var networkErrorDelegate: NetworkErrorDelegate
 

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/home/DetailActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/home/DetailActivity.kt
@@ -55,7 +55,7 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
     private lateinit var fusedLocationClient: FusedLocationProviderClient
     private lateinit var mLocationSource: FusedLocationSource
     private val connectivityObserver: ConnectivityObserver by lazy {
-        NetworkConnectivityObserver.getInstance(this)
+        NetworkConnectivityObserver(applicationContext)
     }
 
     private val reportLauncher =

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/home/ReviewListActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/home/ReviewListActivity.kt
@@ -34,7 +34,7 @@ class ReviewListActivity : AppCompatActivity() {
         ActivityReviewListBinding.inflate(layoutInflater)
     }
     private val connectivityObserver: ConnectivityObserver by lazy {
-        NetworkConnectivityObserver.getInstance(this)
+        NetworkConnectivityObserver(this.applicationContext)
     }
 
     private val reportLauncher =

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/home/WriteReviewActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/home/WriteReviewActivity.kt
@@ -51,7 +51,7 @@ class WriteReviewActivity : AppCompatActivity() {
     private val selectedImages: ArrayList<Uri> = ArrayList()
     private lateinit var imageRVAdapter: WriteReviewImageRVAdapter
     private val connectivityObserver: ConnectivityObserver by lazy {
-        NetworkConnectivityObserver.getInstance(this)
+        NetworkConnectivityObserver(applicationContext)
     }
 
     @SuppressLint("NotifyDataSetChanged")

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/keyword/KeywordSearchActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/keyword/KeywordSearchActivity.kt
@@ -29,7 +29,7 @@ import kr.techit.lion.presentation.observer.NetworkConnectivityObserver
 class KeywordSearchActivity : AppCompatActivity() {
     private val viewModel: KeywordSearchViewModel by viewModels()
     private val connectivityObserver: ConnectivityObserver by lazy {
-        NetworkConnectivityObserver.getInstance(this)
+        NetworkConnectivityObserver(applicationContext)
     }
 
     private lateinit var backPressedCallback: OnBackPressedCallback

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/keyword/fragment/SearchResultFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/keyword/fragment/SearchResultFragment.kt
@@ -28,7 +28,7 @@ import kr.techit.lion.presentation.observer.NetworkConnectivityObserver
 class SearchResultFragment : Fragment(R.layout.fragment_search_result) {
     private val viewModel: SearchResultViewModel by viewModels()
     private val connectivityObserver: ConnectivityObserver by lazy {
-        NetworkConnectivityObserver.getInstance(requireContext())
+        NetworkConnectivityObserver(requireContext().applicationContext)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/main/fragment/HomeMainFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/main/fragment/HomeMainFragment.kt
@@ -73,7 +73,7 @@ class HomeMainFragment : Fragment(R.layout.fragment_home_main) {
     private val retryDelayMillis = 5000L
     private var snapHelper: SnapHelper? = null
     private val connectivityObserver: ConnectivityObserver by lazy {
-        NetworkConnectivityObserver.getInstance(requireContext())
+        NetworkConnectivityObserver(requireContext().applicationContext)
     }
 
     companion object {

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/main/fragment/ScheduleMainFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/main/fragment/ScheduleMainFragment.kt
@@ -40,7 +40,7 @@ class ScheduleMainFragment : Fragment(R.layout.fragment_schedule_main) {
 
     private val viewModel: ScheduleMainViewModel by viewModels()
     private val connectivityObserver: ConnectivityObserver by lazy {
-        NetworkConnectivityObserver.getInstance(requireContext())
+        NetworkConnectivityObserver(requireContext().applicationContext)
     }
 
     private val scheduleReviewLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/main/vm/myinfo/MyInfoMainViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/main/vm/myinfo/MyInfoMainViewModel.kt
@@ -65,8 +65,10 @@ class MyInfoMainViewModel @Inject constructor(
         }
     }
 
-    fun logout(onSuccess: () -> Unit) = viewModelScope.launch{
-        authRepository.logout()
-        onSuccess()
+    fun logout(onSuccess: () -> Unit){
+        viewModelScope.launch{
+            authRepository.logout()
+            onSuccess()
+        }
     }
 }

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/main/vm/search/SearchListViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/main/vm/search/SearchListViewModel.kt
@@ -350,22 +350,26 @@ class SearchListViewModel @Inject constructor(
         }
     }
 
-    fun onMapChanged(state: Boolean) = viewModelScope.launch {
-        mapChanged.emit(state)
+    fun onMapChanged(state: Boolean) {
+        viewModelScope.launch {
+            mapChanged.emit(state)
+        }
     }
 
-    fun onChangeMapState(state: SharedOptionState) = viewModelScope.launch(Dispatchers.IO) {
-        listOptionState.update {
-            if (state.detailFilter.isEmpty()) {
-                it.copy(
-                    disabilityType = TreeSet(),
-                    detailFilter = TreeSet()
-                )
-            } else {
-                it.copy(
-                    disabilityType = state.disabilityType,
-                    detailFilter = state.detailFilter
-                )
+    fun onChangeMapState(state: SharedOptionState) {
+        viewModelScope.launch(Dispatchers.IO) {
+            listOptionState.update {
+                if (state.detailFilter.isEmpty()) {
+                    it.copy(
+                        disabilityType = TreeSet(),
+                        detailFilter = TreeSet()
+                    )
+                } else {
+                    it.copy(
+                        disabilityType = state.disabilityType,
+                        detailFilter = state.detailFilter
+                    )
+                }
             }
         }
     }

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/myinfo/fragment/IceModifyFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/myinfo/fragment/IceModifyFragment.kt
@@ -42,7 +42,7 @@ class IceModifyFragment : Fragment(R.layout.fragment_ice_modify) {
 
     private val viewModel: MyInfoViewModel by activityViewModels()
     private val connectivityObserver: ConnectivityObserver by lazy {
-        NetworkConnectivityObserver.getInstance(requireContext())
+        NetworkConnectivityObserver(requireContext().applicationContext)
     }
     private val myInfoAnnounce = StringBuilder()
 

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/myinfo/fragment/MyInfoFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/myinfo/fragment/MyInfoFragment.kt
@@ -29,7 +29,7 @@ import kr.techit.lion.presentation.observer.NetworkConnectivityObserver
 class MyInfoFragment : Fragment(R.layout.fragment_my_info) {
     private val viewModel: MyInfoViewModel by activityViewModels()
     private val connectivityObserver: ConnectivityObserver by lazy {
-        NetworkConnectivityObserver.getInstance(requireContext())
+        NetworkConnectivityObserver(requireContext().applicationContext)
     }
     private val myInfoAnnounce = StringBuilder()
 

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/myinfo/fragment/PersonalInfoModifyFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/myinfo/fragment/PersonalInfoModifyFragment.kt
@@ -51,7 +51,7 @@ import kr.techit.lion.presentation.observer.NetworkConnectivityObserver
 class PersonalInfoModifyFragment : Fragment(R.layout.fragment_personal_info_modify) {
     private val viewModel: MyInfoViewModel by activityViewModels()
     private val connectivityObserver: ConnectivityObserver by lazy {
-        NetworkConnectivityObserver.getInstance(requireContext())
+        NetworkConnectivityObserver(requireContext().applicationContext)
     }
     private lateinit var pickMedia: ActivityResultLauncher<PickVisualMediaRequest>
     private lateinit var albumLauncher: ActivityResultLauncher<Intent>

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/myinfo/vm/DeleteUserViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/myinfo/vm/DeleteUserViewModel.kt
@@ -20,11 +20,13 @@ class DeleteUserViewModel @Inject constructor(
 
     val networkState get() = networkErrorDelegate.networkState
 
-    fun withdrawal(onSuccess: () -> Unit) = viewModelScope.launch(recordExceptionHandler){
-        authRepository.withdraw().onSuccess {
-            onSuccess()
-        }.onError { e ->
-            networkErrorDelegate.handleNetworkError(e)
+    fun withdrawal(onSuccess: () -> Unit){
+        viewModelScope.launch(recordExceptionHandler) {
+            authRepository.withdraw().onSuccess {
+                onSuccess()
+            }.onError { e ->
+                networkErrorDelegate.handleNetworkError(e)
+            }
         }
     }
 }

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/myinfo/vm/MyInfoViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/myinfo/vm/MyInfoViewModel.kt
@@ -84,16 +84,18 @@ class MyInfoViewModel @Inject constructor(
         }
     }
 
-    fun onCompleteModifyPersonal(nickname: String, phone: String) = viewModelScope.launch {
-        _myPersonalInfo.update { it.copy(nickname = nickname, phone = phone) }
-        _personalModifyState.value = NetworkState.Loading
-        memberRepository.modifyMyPersonalInfo(PersonalInfo(nickname, phone))
-            .onSuccess {
-                _isPersonalInfoModified.value = true
-                _personalModifyState.value = NetworkState.Success
-            }.onError { e ->
-                _personalModifyState.value = NetworkState.Error("${e.title} \n ${e.message}")
-            }
+    fun onCompleteModifyPersonal(nickname: String, phone: String) {
+        viewModelScope.launch {
+            _myPersonalInfo.update { it.copy(nickname = nickname, phone = phone) }
+            _personalModifyState.value = NetworkState.Loading
+            memberRepository.modifyMyPersonalInfo(PersonalInfo(nickname, phone))
+                .onSuccess {
+                    _isPersonalInfoModified.value = true
+                    _personalModifyState.value = NetworkState.Success
+                }.onError { e ->
+                    _personalModifyState.value = NetworkState.Error("${e.title} \n ${e.message}")
+                }
+        }
     }
 
     fun onCompleteModifyPersonalWithImg(nickname: String, phone: String) {
@@ -109,7 +111,8 @@ class MyInfoViewModel @Inject constructor(
                     _personalModifyState.value = NetworkState.Success
                 }.onError { e ->
                     networkErrorDelegate.handleNetworkError(e)
-                    _personalModifyState.value = NetworkState.Error("${e.title} \n ${e.message}")
+                    _personalModifyState.value =
+                        NetworkState.Error("${e.title} \n ${e.message}")
                 }
         }
     }

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/myreview/fragment/MyReviewFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/myreview/fragment/MyReviewFragment.kt
@@ -30,7 +30,7 @@ class MyReviewFragment : Fragment(R.layout.fragment_my_review) {
 
     private val viewModel: MyReviewViewModel by activityViewModels()
     private val connectivityObserver: ConnectivityObserver by lazy {
-        NetworkConnectivityObserver.getInstance(requireContext())
+        NetworkConnectivityObserver(requireContext().applicationContext)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/myreview/fragment/MyReviewModifyFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/myreview/fragment/MyReviewModifyFragment.kt
@@ -48,7 +48,7 @@ class MyReviewModifyFragment : Fragment(R.layout.fragment_my_review_modify) {
 
     private val viewModel: MyReviewViewModel by activityViewModels()
     private val connectivityObserver: ConnectivityObserver by lazy {
-        NetworkConnectivityObserver.getInstance(requireContext())
+        NetworkConnectivityObserver(requireContext().applicationContext)
     }
     private val selectedImages: ArrayList<Uri> = ArrayList()
     private val imageRVAdapter: MyReviewModifyImageRVAdapter by lazy {

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/myschedule/MyScheduleActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/myschedule/MyScheduleActivity.kt
@@ -36,7 +36,7 @@ class MyScheduleActivity : AppCompatActivity() {
     }
 
     private val connectivityObserver: ConnectivityObserver by lazy {
-        NetworkConnectivityObserver.getInstance(this)
+        NetworkConnectivityObserver(applicationContext)
     }
 
     private val scheduleLauncher =

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/observer/NetworkConnectivityObserver.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/observer/NetworkConnectivityObserver.kt
@@ -12,7 +12,9 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import javax.inject.Singleton
 
+@Singleton
 class NetworkConnectivityObserver(
     context: Context
 ): ConnectivityObserver {
@@ -57,17 +59,5 @@ class NetworkConnectivityObserver(
                 connectivityManager.unregisterNetworkCallback(callback)
             }
         }.distinctUntilChanged()
-    }
-
-    companion object{
-
-        @Volatile
-        private var INSTANCE: NetworkConnectivityObserver? = null
-
-        fun getInstance(context: Context): ConnectivityObserver{
-            return INSTANCE ?: synchronized(this){
-                INSTANCE ?: NetworkConnectivityObserver(context).also { INSTANCE = it }
-            }
-        }
     }
 }

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/report/ReportActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/report/ReportActivity.kt
@@ -28,7 +28,7 @@ class ReportActivity : AppCompatActivity() {
     }
     private val viewModel: ReportViewModel by viewModels()
     private val connectivityObserver: ConnectivityObserver by lazy {
-        NetworkConnectivityObserver.getInstance(this@ReportActivity)
+        NetworkConnectivityObserver(applicationContext)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/schedule/PublicScheduleActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/schedule/PublicScheduleActivity.kt
@@ -24,7 +24,7 @@ class PublicScheduleActivity : AppCompatActivity() {
     private val viewModel: PublicScheduleViewModel by viewModels()
 
     private val connectivityObserver: ConnectivityObserver by lazy {
-        NetworkConnectivityObserver.getInstance(this)
+        NetworkConnectivityObserver(applicationContext)
     }
 
     private val binding: ActivityPublicScheduleBinding by lazy {

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/schedule/ScheduleDetailActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/schedule/ScheduleDetailActivity.kt
@@ -56,7 +56,7 @@ class ScheduleDetailActivity : AppCompatActivity() {
     }
 
     private val connectivityObserver: ConnectivityObserver by lazy {
-        NetworkConnectivityObserver.getInstance(this)
+        NetworkConnectivityObserver(applicationContext)
     }
 
     private val scheduleReviewLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) { result ->


### PR DESCRIPTION
## #️⃣연관된 이슈

- #292 

## 📝작업 내용

- 네트워크 옵저빙 클래스 수정

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 💬리뷰 요구사항(선택)

- 기존에 자바 방식의 싱글톤 인스턴스 생성 object 키워드를 사용해 수정했습니다.

- 기존 방식에서 액티비티의 Context를 싱글톤 객체에 전달하면 메모리 누수(memory leak) 문제가 발생할 수 있어
  어플리케이션 전체의 생명주기를 따르는 applicationContext를 사용하면 싱글톤 클래스에서 메모리 누수없이 사용할 수 있다고
 생각해서 현재와 같이 수정했습니다.
