### PR TITLE
#296 관심유형 선택 후 화면 이동 불가시 재시도 버튼 추가

### DIFF
--- a/DaOnGil/domain/src/main/java/kr/techit/lion/domain/model/ConcernType.kt
+++ b/DaOnGil/domain/src/main/java/kr/techit/lion/domain/model/ConcernType.kt
@@ -6,7 +6,20 @@ data class ConcernType(
     val isVisual: Boolean,
     val isElderly: Boolean,
     val isChild: Boolean,
-)
+) {
+    companion object {
+        fun create(): ConcernType {
+            return ConcernType(
+                isPhysical = false,
+                isHear = false,
+                isVisual = false,
+                isElderly = false,
+                isChild = false
+            )
+        }
+    }
+
+}
 
 fun ConcernType.hasAnyTrue(): Boolean {
     return listOf(isPhysical, isHear, isVisual, isElderly, isChild).any { it }

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/delegate/NetworkErrorDelegate.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/delegate/NetworkErrorDelegate.kt
@@ -29,7 +29,7 @@ class NetworkErrorDelegate @Inject constructor() {
             is ConnectException -> ConnectError
             is SocketTimeoutException -> TimeoutError
             is UnknownHostException -> UnknownHostError
-            is HttpException -> { // HttpException으로 변경
+            is HttpException -> {
                 when (e.code()) {
                     400 -> BadRequestError
                     401 -> AuthenticationError

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/login/fragment/LoginFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/login/fragment/LoginFragment.kt
@@ -19,6 +19,7 @@ import kr.techit.lion.presentation.R
 import kr.techit.lion.presentation.databinding.FragmentLoginBinding
 import kr.techit.lion.presentation.ext.repeatOnViewStarted
 import kr.techit.lion.presentation.login.model.LoginType
+import kr.techit.lion.presentation.login.model.UserState
 import kr.techit.lion.presentation.login.vm.LoginViewModel
 import kr.techit.lion.presentation.main.MainActivity
 
@@ -32,7 +33,6 @@ class LoginFragment : Fragment(R.layout.fragment_login) {
         val binding = FragmentLoginBinding.bind(view)
 
         with(binding) {
-
             kakaoLoginButton.setOnClickListener {
                 kakaoLogin(binding)
             }
@@ -47,13 +47,15 @@ class LoginFragment : Fragment(R.layout.fragment_login) {
         }
 
         repeatOnViewStarted {
-            viewModel.sigInInUiState.collectLatest {
-                if (it) {
-                    if (viewModel.isFirstUser.value) {
+            viewModel.userState.collect { state ->
+                when (state) {
+                    UserState.Checking -> return@collect
+                    UserState.NewUser -> {
+                        Navigation.findNavController(view).navigate(R.id.to_selectInterestFragment)
+                    }
+                    UserState.ExistingUser -> {
                         startActivity(Intent(requireContext(), MainActivity::class.java))
                         requireActivity().finish()
-                    }else{
-                        Navigation.findNavController(view).navigate(R.id.to_selectInterestFragment)
                     }
                 }
             }
@@ -81,7 +83,10 @@ class LoginFragment : Fragment(R.layout.fragment_login) {
                     }
 
                     // 카카오톡에 연결된 카카오계정이 없는 경우, 카카오계정으로 로그인 시도
-                    UserApiClient.instance.loginWithKakaoAccount(requireContext(), callback = callback)
+                    UserApiClient.instance.loginWithKakaoAccount(
+                        requireContext(),
+                        callback = callback
+                    )
                 } else if (token != null) {
                     viewModel.onCompleteLogIn(kakao, token.accessToken, token.refreshToken)
                 }
@@ -111,7 +116,7 @@ class LoginFragment : Fragment(R.layout.fragment_login) {
                 binding.progressbar.visibility = View.GONE
                 val errorCode = NaverIdLoginSDK.getLastErrorCode().code
                 val errorDescription = NaverIdLoginSDK.getLastErrorDescription()
-                Log.d("NaverLoginFailed", "$errorCode : $errorDescription" )
+                Log.d("NaverLoginFailed", "$errorCode : $errorDescription")
             }
 
             override fun onError(errorCode: Int, message: String) {

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/login/fragment/SelectInterestFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/login/fragment/SelectInterestFragment.kt
@@ -45,8 +45,12 @@ class SelectInterestFragment : Fragment(R.layout.fragment_select_interest) {
             }
         }
 
-        binding.selectInterestCompleteButton.setOnClickListener {
+        binding.btnSubmit.setOnClickListener {
             binding.progressBar.visibility = View.VISIBLE
+            viewModel.onClickSubmitButton()
+        }
+
+        binding.btnRetry.setOnClickListener {
             viewModel.onClickSubmitButton()
         }
 
@@ -63,8 +67,9 @@ class SelectInterestFragment : Fragment(R.layout.fragment_select_interest) {
             when(it) {
                 is NetworkState.Loading -> return@collect
                 is NetworkState.Error -> {
+                    binding.btnRetry.visibility = View.VISIBLE
                     binding.progressBar.visibility = View.GONE
-                    Snackbar.make(binding.root, it.msg, Snackbar.LENGTH_SHORT).show()
+                    Snackbar.make(binding.root, getString(R.string.plz_retry), Snackbar.LENGTH_SHORT).show()
                 }
                 is NetworkState.Success -> {
                     binding.progressBar.visibility = View.GONE
@@ -76,7 +81,7 @@ class SelectInterestFragment : Fragment(R.layout.fragment_select_interest) {
     }
 
     private suspend fun collectConcernType(binding: FragmentSelectInterestBinding) {
-        viewModel.concernType.collectLatest { concernType ->
+        viewModel.state.collectLatest { concernType ->
             updateUI(binding, concernType)
         }
     }
@@ -99,9 +104,9 @@ class SelectInterestFragment : Fragment(R.layout.fragment_select_interest) {
         )
 
         val anySelected = concernType.hasAnyTrue()
-        binding.selectInterestCompleteButton.isEnabled = anySelected
+        binding.btnSubmit.isEnabled = anySelected
         if (requireContext().isTallBackEnabled() && !anySelected){
-            binding.selectInterestCompleteButton.contentDescription = "관심유형을 한개 이상선택해주세요"
+            binding.btnSubmit.contentDescription = getString(R.string.plz_select_interest_type)
         }
     }
 }

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/login/model/UserState.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/login/model/UserState.kt
@@ -1,0 +1,7 @@
+package kr.techit.lion.presentation.login.model
+
+sealed class UserState {
+    object Checking: UserState()
+    object ExistingUser: UserState()
+    object NewUser: UserState()
+}

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/login/vm/InterestViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/login/vm/InterestViewModel.kt
@@ -27,18 +27,12 @@ class InterestViewModel @Inject constructor(
 
     val networkState: StateFlow<NetworkState> get() = networkErrorDelegate.networkState
 
-    private val _concernType = MutableStateFlow(ConcernType(
-        isPhysical = false,
-        isHear = false,
-        isVisual = false,
-        isElderly = false,
-        isChild = false
-    ))
+    private val _state = MutableStateFlow(ConcernType.create())
 
-    val concernType get() = _concernType.asStateFlow()
+    val state get() = _state.asStateFlow()
 
     fun onSelectInterest(type: InterestType) {
-        val currentInterests = _concernType.value
+        val currentInterests = _state.value
 
         val updatedInterests = when(type) {
             InterestType.Physical -> currentInterests.copy(isPhysical = !currentInterests.isPhysical)
@@ -48,12 +42,12 @@ class InterestViewModel @Inject constructor(
             InterestType.Elderly -> currentInterests.copy(isElderly = !currentInterests.isElderly)
         }
 
-        _concernType.update { updatedInterests }
+        _state.update { updatedInterests }
     }
 
     fun onClickSubmitButton() {
         viewModelScope.launch(recordExceptionHandler){
-            memberRepository.updateConcernType(_concernType.value).onSuccess {
+            memberRepository.updateConcernType(_state.value).onSuccess {
                 networkErrorDelegate.handleNetworkSuccess()
             }.onError {
                 networkErrorDelegate.handleNetworkError(it)

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/login/vm/LoginViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/login/vm/LoginViewModel.kt
@@ -4,14 +4,17 @@ import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kr.techit.lion.domain.exception.onError
 import kr.techit.lion.domain.exception.onSuccess
+import kr.techit.lion.domain.model.ConcernType
 import kr.techit.lion.domain.model.hasAnyTrue
 import kr.techit.lion.domain.repository.AuthRepository
 import kr.techit.lion.domain.repository.MemberRepository
 import kr.techit.lion.presentation.base.BaseViewModel
 import kr.techit.lion.presentation.delegate.NetworkErrorDelegate
+import kr.techit.lion.presentation.login.model.UserState
 import javax.inject.Inject
 
 @HiltViewModel
@@ -22,29 +25,34 @@ class LoginViewModel @Inject constructor(
 
     @Inject
     lateinit var networkErrorDelegate: NetworkErrorDelegate
-
     val networkState get() = networkErrorDelegate.networkState
 
-    private val _sigInInUiState = MutableStateFlow(false)
-    val sigInInUiState = _sigInInUiState.asStateFlow()
+    private val _userState = MutableStateFlow<UserState>(UserState.Checking)
+    val userState = _userState.asStateFlow()
 
-    private val _isFirstUser = MutableStateFlow(false)
-    val isFirstUser = _isFirstUser.asStateFlow()
-
-    fun onCompleteLogIn(type: String, accessToken: String, refreshToken: String){
+    fun onCompleteLogIn(type: String, accessToken: String, refreshToken: String) {
         viewModelScope.launch(recordExceptionHandler) {
             authRepository.signIn(type, accessToken, refreshToken)
-            checkIsFirstUser()
-            _sigInInUiState.value = true
+            checkUserState()
         }
     }
 
-    private suspend fun checkIsFirstUser(){
-        memberRepository.getConcernType().onSuccess { ConcernType ->
-            _isFirstUser.value = ConcernType.hasAnyTrue()
-            networkErrorDelegate.handleNetworkSuccess()
-        }.onError {
-            networkErrorDelegate.handleNetworkError(it)
+    private fun checkUserState() {
+        viewModelScope.launch {
+            memberRepository.getConcernType().onSuccess { type ->
+                modifyUserState(type)
+                networkErrorDelegate.handleNetworkSuccess()
+            }.onError {
+                networkErrorDelegate.handleNetworkError(it)
+            }
+        }
+    }
+
+    private fun modifyUserState(type: ConcernType){
+        if (type.hasAnyTrue()) {
+            _userState.update { UserState.ExistingUser }
+        } else {
+            _userState.update { UserState.NewUser }
         }
     }
 }

--- a/DaOnGil/presentation/src/main/res/layout/fragment_select_interest.xml
+++ b/DaOnGil/presentation/src/main/res/layout/fragment_select_interest.xml
@@ -120,12 +120,28 @@
     </LinearLayout>
 
     <Button
-        android:id="@+id/selectInterestCompleteButton"
+        android:id="@+id/btn_retry"
         android:layout_width="match_parent"
         android:layout_height="55dp"
         android:layout_marginBottom="@dimen/margin_big4"
         android:fontFamily="@font/pretendard_bold"
-        android:text="완료"
+        android:text="@string/text_retry"
+        android:textColor="@color/white"
+        android:visibility="gone"
+        android:backgroundTint="@color/button_tertiary"
+        android:textSize="@dimen/font_big1"
+        app:layout_constraintBottom_toTopOf="@id/btn_submit"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+
+    <Button
+        android:id="@+id/btn_submit"
+        android:layout_width="match_parent"
+        android:layout_height="55dp"
+        android:layout_marginBottom="@dimen/margin_big4"
+        android:fontFamily="@font/pretendard_bold"
+        android:text="@string/text_complete"
         android:textSize="@dimen/font_big1"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"

--- a/DaOnGil/presentation/src/main/res/values/strings.xml
+++ b/DaOnGil/presentation/src/main/res/values/strings.xml
@@ -420,5 +420,9 @@
     <string name="text_my_review_img">후기 이미지 두 번 탭하면 이미지 보기 화면으로 이동합니다</string>
     <string name="text_my_review_modify_move">후기 수정하기</string>
     <string name="text_my_review_delete">후기 삭제하기</string>
-    <string name="text_common_error">오류가 발갱했습니다. 앱 종료 후 다시 시도해주세요.</string>
+    <string name="text_common_error">오류가 발생했습니다. 앱 종료 후 다시 시도해주세요.</string>
+    <string name="text_complete">완료</string>
+    <string name="text_retry">다시 시도</string>
+    <string name="plz_select_interest_type">"관심유형을 한개 이상선택해주세요"</string>
+    <string name="plz_retry">서버 호출에 실패했어요. 버튼을 눌러 다시 시도해주세요.</string>
 </resources>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #296 

## 📝작업 내용

- 네이버 로그인 Secret 변경
- 관심유형 선택 화면에서 API 호출 에러일 때 만 보이는 재시도 버튼 추가

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
- 사진 

## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  - ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요
