### PR TITLE
[#304]사용자 테마 가져오기 flow로 수정

### DIFF
--- a/DaOnGil/data/src/main/java/kr/techit/lion/data/datasource/AppThemeDataSource.kt
+++ b/DaOnGil/data/src/main/java/kr/techit/lion/data/datasource/AppThemeDataSource.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kr.techit.lion.data.database.AppSettings
 import kr.techit.lion.data.database.dataStore
 import kr.techit.lion.domain.model.AppTheme
@@ -11,20 +12,14 @@ import javax.inject.Inject
 
 class AppThemeDataSource @Inject constructor(
     private val context: Context,
-){
+) {
     private val dataStore: DataStore<AppSettings>
         get() = context.dataStore
 
-    private val data: Flow<AppSettings>
-        get() = dataStore.data
+    val appTheme: Flow<AppTheme>
+        get() = dataStore.data.map { it.appTheme }
 
-    suspend fun getAppTheme(): AppTheme = data.first().appTheme
-
-    suspend fun saveAppTheme(appTheme: AppTheme){
-        dataStore.updateData {
-            it.copy(
-                appTheme = appTheme
-            )
-        }
+    suspend fun saveAppTheme(appTheme: AppTheme) {
+        dataStore.updateData { it.copy(appTheme = appTheme) }
     }
 }

--- a/DaOnGil/data/src/main/java/kr/techit/lion/data/repository/AppThemeRepositoryImpl.kt
+++ b/DaOnGil/data/src/main/java/kr/techit/lion/data/repository/AppThemeRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package kr.techit.lion.data.repository
 
+import kotlinx.coroutines.flow.Flow
 import kr.techit.lion.data.datasource.AppThemeDataSource
 import kr.techit.lion.domain.model.AppTheme
 import kr.techit.lion.domain.repository.AppThemeRepository
@@ -9,8 +10,8 @@ class AppThemeRepositoryImpl @Inject constructor(
     private val appThemeDataSource: AppThemeDataSource
 ): AppThemeRepository {
 
-    override suspend fun getAppTheme(): AppTheme {
-        return appThemeDataSource.getAppTheme()
+    override fun getAppTheme(): Flow<AppTheme> {
+        return appThemeDataSource.appTheme
     }
 
     override suspend fun saveAppTheme(appTheme: AppTheme) {

--- a/DaOnGil/domain/src/main/java/kr/techit/lion/domain/model/AppTheme.kt
+++ b/DaOnGil/domain/src/main/java/kr/techit/lion/domain/model/AppTheme.kt
@@ -1,5 +1,19 @@
 package kr.techit.lion.domain.model
 
 enum class AppTheme {
-    LIGHT, HIGH_CONTRAST, SYSTEM
+    LIGHT, HIGH_CONTRAST, SYSTEM, LOADING;
+
+    companion object {
+        fun getNewTheme(theme: AppTheme, isDarkTheme: Boolean): AppTheme{
+            return when (theme) {
+                LIGHT -> HIGH_CONTRAST
+                HIGH_CONTRAST -> LIGHT
+                SYSTEM -> {
+                    if (isDarkTheme) LIGHT else HIGH_CONTRAST
+                }
+                LOADING -> return LOADING
+            }
+        }
+    }
+
 }

--- a/DaOnGil/domain/src/main/java/kr/techit/lion/domain/repository/AppThemeRepository.kt
+++ b/DaOnGil/domain/src/main/java/kr/techit/lion/domain/repository/AppThemeRepository.kt
@@ -1,8 +1,9 @@
 package kr.techit.lion.domain.repository
 
+import kotlinx.coroutines.flow.Flow
 import kr.techit.lion.domain.model.AppTheme
 
 interface AppThemeRepository {
-    suspend fun getAppTheme(): AppTheme
+    fun getAppTheme(): Flow<AppTheme>
     suspend fun saveAppTheme(appTheme: AppTheme)
 }

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/main/vm/home/HomeViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/main/vm/home/HomeViewModel.kt
@@ -71,32 +71,28 @@ class HomeViewModel @Inject constructor(
         val appTheme = appThemeRepository.getAppTheme()
         _appTheme.value = appTheme
     }
+    val appTheme = appThemeRepository.getAppTheme().stateInUi(
+        viewModelScope, AppTheme.LOADING
+    )
 
     private fun setAppTheme(appTheme: AppTheme) {
         viewModelScope.launch {
             appThemeRepository.saveAppTheme(appTheme)
-            _appTheme.update { appTheme }
         }
     }
 
     // 상단 테마 토글 버튼 클릭시
     fun onClickThemeToggleButton(isDarkTheme: Boolean) {
-
-        val newAppTheme = when (_appTheme.value) {
-            AppTheme.LIGHT -> AppTheme.HIGH_CONTRAST
-            AppTheme.HIGH_CONTRAST -> AppTheme.LIGHT
-            AppTheme.SYSTEM -> {
-                if (isDarkTheme) AppTheme.LIGHT else AppTheme.HIGH_CONTRAST
-            }
-        }
-
+        val newAppTheme = getNewTheme(appTheme.value, isDarkTheme)
         setAppTheme(newAppTheme)
     }
 
     // 테마 설정 다이얼로그 클릭시
-    fun onClickThemeChangeButton(theme: AppTheme) = viewModelScope.launch {
-        setAppTheme(theme)
-        activationRepository.saveUserActivation(false)
+    fun onClickThemeChangeButton(theme: AppTheme){
+        viewModelScope.launch {
+            setAppTheme(theme)
+            activationRepository.saveUserActivation(false)
+        }
     }
 
     fun getPlaceMain(area: String, sigungu: String) = viewModelScope.launch(Dispatchers.IO) {


### PR DESCRIPTION
## #️⃣연관된 이슈

- #304

## 📝작업 내용

- Data Store에 저장된 테마 타입을 Flow로 수정했습니다.

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 💬리뷰 요구사항(선택)

- 기존 로직에선 타입이 임의로 정이한 AppTheme Type이기 때문에
Data Store에 저장된 테마 가져오기 -> 해당 테마로 변경 -> 고대비 버튼으로 테마 변경 ->
테마 상태를 구독하는 StateFlow 수정 -> Data Store 수정 -> 요 플로우로 흘려갑니다.
이 경우 테마 변경시 테마 상태를 구독하는 StateFlow 직접 수정해야하기 때문에
이를 Flow로 수정하면
Data Store에 저장된 테마 가져오기 -> 해당 테마로 변경 -> 고대비 버튼으로 테마 변경 ->
Data Store 수정 -> StateFlow는 변경된 테마 상태를 실시간으로 읽어옴

이렇게 구현이 가능해서 수정했습니다.
