### PR TITLE
[#303] 사용자 이름 수정 기능 추가

### DIFF
--- a/DaOnGil/data/src/main/java/kr/techit/lion/data/dto/request/MyPersonalInfoRequest.kt
+++ b/DaOnGil/data/src/main/java/kr/techit/lion/data/dto/request/MyPersonalInfoRequest.kt
@@ -15,7 +15,7 @@ internal data class MyPersonalInfoRequest(
 internal fun PersonalInfo.toRequestBody(): RequestBody {
     return JsonAdapter(MyPersonalInfoRequest::class.java).toJson(
         MyPersonalInfoRequest(
-            this.useName,
+            this.userName,
             this.nickname,
             this.phone
         )

--- a/DaOnGil/data/src/main/java/kr/techit/lion/data/dto/request/MyPersonalInfoRequest.kt
+++ b/DaOnGil/data/src/main/java/kr/techit/lion/data/dto/request/MyPersonalInfoRequest.kt
@@ -7,6 +7,7 @@ import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 
 internal data class MyPersonalInfoRequest(
+    val name: String,
     val nickname: String,
     val phone: String
 )
@@ -14,6 +15,7 @@ internal data class MyPersonalInfoRequest(
 internal fun PersonalInfo.toRequestBody(): RequestBody {
     return JsonAdapter(MyPersonalInfoRequest::class.java).toJson(
         MyPersonalInfoRequest(
+            this.useName,
             this.nickname,
             this.phone
         )

--- a/DaOnGil/domain/src/main/java/kr/techit/lion/domain/model/IceInfo.kt
+++ b/DaOnGil/domain/src/main/java/kr/techit/lion/domain/model/IceInfo.kt
@@ -1,13 +1,27 @@
 package kr.techit.lion.domain.model
 
 data class IceInfo(
-    val bloodType: String = "",
-    val birth: String = "",
-    val disease: String = "",
-    val allergy: String = "",
-    val medication: String = "",
-    val part1Rel: String = "",
-    val part1Phone: String = "",
-    val part2Rel: String = "",
-    val part2Phone: String = ""
-)
+    val bloodType: String,
+    val birth: String,
+    val disease: String,
+    val allergy: String,
+    val medication: String,
+    val part1Rel: String,
+    val part1Phone: String,
+    val part2Rel: String,
+    val part2Phone: String,
+){
+    companion object{
+        fun create() = IceInfo(
+            bloodType = "",
+            birth = "",
+            disease = "",
+            allergy = "",
+            medication = "",
+            part1Rel = "",
+            part1Phone = "",
+            part2Rel = "",
+            part2Phone = ""
+        )
+    }
+}

--- a/DaOnGil/domain/src/main/java/kr/techit/lion/domain/model/PersonalInfo.kt
+++ b/DaOnGil/domain/src/main/java/kr/techit/lion/domain/model/PersonalInfo.kt
@@ -1,6 +1,17 @@
 package kr.techit.lion.domain.model
 
 data class PersonalInfo (
-    val nickname: String = "",
-    val phone: String = ""
-)
+    val useName: String,
+    val nickname: String,
+    val phone: String
+){
+    companion object{
+        fun create(): PersonalInfo{
+            return PersonalInfo(
+                useName = "",
+                nickname = "",
+                phone = ""
+            )
+        }
+    }
+}

--- a/DaOnGil/domain/src/main/java/kr/techit/lion/domain/model/PersonalInfo.kt
+++ b/DaOnGil/domain/src/main/java/kr/techit/lion/domain/model/PersonalInfo.kt
@@ -1,14 +1,14 @@
 package kr.techit.lion.domain.model
 
 data class PersonalInfo (
-    val useName: String,
+    val userName: String,
     val nickname: String,
     val phone: String
 ){
     companion object{
         fun create(): PersonalInfo{
             return PersonalInfo(
-                useName = "",
+                userName = "",
                 nickname = "",
                 phone = ""
             )

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/main/vm/myinfo/model/ProfileState.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/main/vm/myinfo/model/ProfileState.kt
@@ -1,0 +1,18 @@
+package kr.techit.lion.presentation.main.vm.myinfo.model
+
+import kr.techit.lion.domain.model.MyDefaultInfo
+import kr.techit.lion.presentation.splash.model.LogInState
+
+data class ProfileState(
+    val loginState: LogInState,
+    val myInfo: MyDefaultInfo
+){
+    companion object{
+        fun create(): ProfileState{
+            return ProfileState(
+                loginState = LogInState.Checking,
+                myInfo = MyDefaultInfo()
+            )
+        }
+    }
+}

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/myinfo/intent/MyInfoIntent.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/myinfo/intent/MyInfoIntent.kt
@@ -1,0 +1,12 @@
+package kr.techit.lion.presentation.myinfo.intent
+
+import kr.techit.lion.domain.model.IceInfo
+import kr.techit.lion.domain.model.PersonalInfo
+
+sealed interface MyInfoIntent {
+    object OnUiEventInitializeUiData : MyInfoIntent
+    data class OnUiEventModifyPersonalInfo(val PersonalInfo: PersonalInfo) : MyInfoIntent
+    data class OnUiEventModifyIceInfo(val newIceInfo: IceInfo) : MyInfoIntent
+    data class OnUiEventSelectProfileImage(val imgUrl: String?) : MyInfoIntent
+}
+

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/myinfo/model/MyInfoState.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/myinfo/model/MyInfoState.kt
@@ -1,0 +1,29 @@
+package kr.techit.lion.presentation.myinfo.model
+
+import kr.techit.lion.domain.model.IceInfo
+import kr.techit.lion.domain.model.PersonalInfo
+import kr.techit.lion.presentation.delegate.NetworkState
+
+data class MyInfoState(
+    val personalInfo: PersonalInfo,
+    val iceInfo: IceInfo,
+    val profileImg: UserProfileImg,
+    val personalModifyNetworkState: NetworkState,
+    val iceModifyNetworkState: NetworkState,
+    val imgSelectedState: ImgModifyState,
+    val isPersonalInfoModified: Boolean
+) {
+    companion object {
+        fun create(): MyInfoState {
+            return MyInfoState(
+                personalInfo = PersonalInfo.create(),
+                iceInfo = IceInfo.create(),
+                profileImg = UserProfileImg(""),
+                personalModifyNetworkState = NetworkState.Loading,
+                iceModifyNetworkState = NetworkState.Loading,
+                imgSelectedState = ImgModifyState.ImgUnSelected,
+                isPersonalInfoModified = false
+            )
+        }
+    }
+}

--- a/DaOnGil/presentation/src/main/res/layout/fragment_personal_info_modify.xml
+++ b/DaOnGil/presentation/src/main/res/layout/fragment_personal_info_modify.xml
@@ -51,7 +51,6 @@
             android:id="@+id/constraintLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:padding="@dimen/margin_basic"
             app:layout_constraintTop_toTopOf="parent">
 
             <com.google.android.material.card.MaterialCardView
@@ -76,7 +75,7 @@
             </com.google.android.material.card.MaterialCardView>
 
             <Button
-                android:id="@+id/btn_modify"
+                android:id="@+id/btn_img_modify"
                 style="?attr/materialIconButtonFilledTonalStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
@@ -95,12 +94,49 @@
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <LinearLayout
+            android:id="@+id/linearLayout6"
             android:layout_width="match_parent"
             android:layout_height="0dp"
             android:orientation="vertical"
-            android:padding="@dimen/margin_basic"
-            app:layout_constraintBottom_toTopOf="@+id/linearLayout"
+            android:padding="16dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/constraintLayout">
+
+            <TextView
+                android:id="@+id/tv_userName_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/margin_small1"
+                android:fontFamily="@font/pretendard_medium"
+                android:text="@string/text_name"
+                android:textSize="@dimen/font_big2" />
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/textInputLayoutUserName"
+                style="?attr/materialAlertDialogBodyTextStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/margin_small2"
+                app:boxBackgroundColor="@color/text_field_background"
+                app:boxBackgroundMode="outline"
+                app:boxStrokeColor="@color/text_field_background"
+                app:boxStrokeWidth="0dp"
+                app:cursorColor="@color/text_primary"
+                app:endIconMode="clear_text"
+                app:errorEnabled="true"
+                app:hintEnabled="false"
+                tools:boxBackgroundMode="outline">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/tv_name"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:fontFamily="@font/pretendard_medium"
+                    android:hint="@string/text_plz_enter_name"
+                    android:inputType="text"
+                    android:textSize="@dimen/font_big3" />
+            </com.google.android.material.textfield.TextInputLayout>
 
             <TextView
                 android:id="@+id/tv_nickname_title"
@@ -116,7 +152,7 @@
                 style="?attr/materialAlertDialogBodyTextStyle"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/margin_big4"
+                android:layout_marginBottom="@dimen/margin_small2"
                 app:boxBackgroundColor="@color/text_field_background"
                 app:boxBackgroundMode="outline"
                 app:boxStrokeColor="@color/text_field_background"
@@ -150,7 +186,6 @@
                 android:id="@+id/textInputLayoutUserPhoneNumber"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="@dimen/margin_big2"
                 app:boxBackgroundColor="@color/text_field_background"
                 app:boxBackgroundMode="outline"
                 app:boxStrokeColor="@color/text_field_background"
@@ -163,30 +198,28 @@
                 <com.google.android.material.textfield.TextInputEditText
                     android:id="@+id/tv_phone"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
+                    android:layout_height="match_parent"
                     android:fontFamily="@font/pretendard_medium"
                     android:hint="@string/text_contact_ex"
                     android:inputType="phone"
                     android:textSize="@dimen/font_big3" />
             </com.google.android.material.textfield.TextInputLayout>
         </LinearLayout>
-        <LinearLayout
-            android:id="@+id/linearLayout"
+
+
+        <Button
+            android:id="@+id/btn_submit"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:padding="@dimen/margin_basic"
-            app:layout_constraintBottom_toBottomOf="parent">
-
-            <Button
-                android:id="@+id/btn_submit"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:background="@drawable/background_radius_10"
-                android:fontFamily="@font/pretendard_bold"
-                android:text="@string/text_modify"
-                android:textSize="@dimen/font_big2" />
-        </LinearLayout>
+            android:background="@drawable/background_radius_10"
+            android:fontFamily="@font/pretendard_bold"
+            android:text="@string/text_modify"
+            android:layout_marginHorizontal="@dimen/margin_big3"
+            android:layout_marginBottom="@dimen/margin_big3"
+            android:textSize="@dimen/font_big2"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <ProgressBar

--- a/DaOnGil/presentation/src/main/res/values/strings.xml
+++ b/DaOnGil/presentation/src/main/res/values/strings.xml
@@ -147,6 +147,7 @@
     <string name="content_emergency_area_dialog">시도와 시군구 모두 선택해주세요</string>
     <string name="text_relation">관계</string>
     <string name="text_birth">생년월일</string>
+    <string name="text_plz_enter_name">이름을 입력해주세요</string>
     <string name="text_plz_enter_nickname">닉네임을 입력해주세요</string>
     <string name="text_plz_enter_birth">생년월일을 입력해주세요</string>
     <string name="text_blood_type">혈액형</string>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #303

## 📝작업 내용

- 사용자 프로필 이름 수정 기능 추가
- 사용자 프로필 수정 로직 MVI로 변경

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)

<img width="650" alt="image" src="https://github.com/user-attachments/assets/da833532-fe40-4456-955e-173ce2cd8fbc">
<img width="700" alt="image" src="https://github.com/user-attachments/assets/e3e7b666-e6db-4ea2-9590-6fb3e5158c01">

## 💬리뷰 요구사항(선택)

- 기존 코드를 다시 보니까 참 개판이네요 ㅎㅎ... 저 시절엔 저게 최선이었나 봅니다 ㅎㅎ..
코드가 너무 난장판이라 일단 MVI 스럽게 수정해봤습니다
지금도 수정하고 싶은거 한트럭이지만 너무 바쁜 관계로 시간 나는대로 틈틈히 해보겠습니다 ㅠㅠ
