### PR TITLE
[#321] api 호출시 에러처리 수정

### DIFF
--- a/DaOnGil/data/src/main/java/kr/techit/lion/data/common/NetworkResultHandler.kt
+++ b/DaOnGil/data/src/main/java/kr/techit/lion/data/common/NetworkResultHandler.kt
@@ -1,16 +1,16 @@
 package kr.techit.lion.data.common
 
-import kr.techit.lion.domain.exception.AuthenticationError
-import kr.techit.lion.domain.exception.AuthorizationError
-import kr.techit.lion.domain.exception.BadRequestError
-import kr.techit.lion.domain.exception.ConnectError
+import kr.techit.lion.domain.exception.HttpError.AuthenticationError
+import kr.techit.lion.domain.exception.HttpError.AuthorizationError
+import kr.techit.lion.domain.exception.HttpError.BadRequestError
+import kr.techit.lion.domain.exception.NetworkError.ConnectError
 import kr.techit.lion.domain.exception.NetworkError
-import kr.techit.lion.domain.exception.NotFoundError
+import kr.techit.lion.domain.exception.HttpError.NotFoundError
 import kr.techit.lion.domain.exception.Result
-import kr.techit.lion.domain.exception.ServerError
-import kr.techit.lion.domain.exception.TimeoutError
-import kr.techit.lion.domain.exception.UnknownError
-import kr.techit.lion.domain.exception.UnknownHostError
+import kr.techit.lion.domain.exception.HttpError.ServerError
+import kr.techit.lion.domain.exception.NetworkError.TimeoutError
+import kr.techit.lion.domain.exception.NetworkError.UnknownError
+import kr.techit.lion.domain.exception.NetworkError.UnknownHostError
 import retrofit2.HttpException
 import java.net.ConnectException
 import java.net.SocketTimeoutException
@@ -39,7 +39,7 @@ fun handleNetworkError(e: Throwable): NetworkError {
         is ConnectException -> ConnectError
         is SocketTimeoutException -> TimeoutError
         is UnknownHostException -> UnknownHostError
-        is HttpException -> { // HttpException으로 변경
+        is HttpException -> {
             when (e.code()) {
                 400 -> BadRequestError
                 401 -> AuthenticationError

--- a/DaOnGil/domain/src/main/java/kr/techit/lion/domain/exception/HttpError.kt
+++ b/DaOnGil/domain/src/main/java/kr/techit/lion/domain/exception/HttpError.kt
@@ -1,39 +1,9 @@
 package kr.techit.lion.domain.exception
 
 sealed class HttpError : NetworkError() {
-    abstract override val title: String
-    abstract override val message: String
-}
-data object BadRequestError : HttpError(){
-    override val title: String
-        get() = "인증 오류가 발생했어요"
-    override val message: String
-        get() = "요청 내용을 확인하고 다시 시도해주세요."
-}
-data object AuthenticationError : HttpError() {
-    override val title: String
-        get() = "로그인 문제가 발생했습니다."
-    override val message: String
-        get() = "문제가 반복 된다면 다시 로그인해주세요."
-}
-
-data object AuthorizationError : HttpError() {
-    override val title: String
-        get() = "서비스 이용 권한에 문제가 발생했습니다."
-    override val message: String
-        get() = "해당 서비스에 대한 유저 권한이 없어요."
-}
-
-data object NotFoundError : HttpError() {
-    override val title: String
-        get() = "해당 서비스를 찾을 수 없어요"
-    override val message: String
-        get() = "요청하신 페이지 또는 정보가 존재하지 않습니다."
-}
-
-data object ServerError : HttpError() {
-    override val title: String
-        get() = "서버에 오류가 발생했어요"
-    override val message: String
-        get() = "잠시후 다시 시도해주세요."
+    data object BadRequestError : HttpError()
+    data object AuthenticationError : HttpError()
+    data object AuthorizationError : HttpError()
+    data object NotFoundError : HttpError()
+    data object ServerError : HttpError()
 }

--- a/DaOnGil/domain/src/main/java/kr/techit/lion/domain/exception/NetworkError.kt
+++ b/DaOnGil/domain/src/main/java/kr/techit/lion/domain/exception/NetworkError.kt
@@ -1,34 +1,8 @@
 package kr.techit.lion.domain.exception
 
 sealed class NetworkError : Throwable(){
-    abstract val title: String
-    abstract override val message: String
-}
-
-data object ConnectError : NetworkError() {
-    override val title: String
-        get() = "서버에 연결할 수 없어요"
-    override val message: String
-        get() = "인터넷 연결을 확인한 후 다시 시도해주세요."
-}
-
-data object TimeoutError : NetworkError() {
-    override val title: String
-        get() = "서버 응답 시간이 초과되었어요"
-    override val message: String
-        get() = "잠시 후 다시 시도해주세요."
-}
-
-data object UnknownHostError : NetworkError() {
-    override val title: String
-        get() = "서버를 찾을 수 없습니다."
-    override val message: String
-        get() = "인터넷 연결 상태를 확인해주세요."
-}
-
-data object UnknownError : NetworkError() {
-    override val title: String
-        get() = "알 수 없는 오류가 발생했어요"
-    override val message: String
-        get() = "잠시 후 다시 시도해주세요."
+    data object ConnectError : NetworkError()
+    data object TimeoutError : NetworkError()
+    data object UnknownHostError : NetworkError()
+    data object UnknownError : NetworkError()
 }

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/base/BaseViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/base/BaseViewModel.kt
@@ -6,14 +6,36 @@ import com.google.firebase.crashlytics.FirebaseCrashlytics
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kr.techit.lion.presentation.delegate.NetworkErrorDelegate
-import javax.inject.Inject
+import kr.techit.lion.domain.exception.onError
+import kr.techit.lion.domain.exception.onSuccess
+import kr.techit.lion.presentation.delegate.NetworkEvent
+import kr.techit.lion.domain.exception.Result
+import kr.techit.lion.presentation.delegate.NetworkEventDelegate
 
 open class BaseViewModel : ViewModel() {
 
     protected val recordExceptionHandler = CoroutineExceptionHandler { _, throwable ->
         viewModelScope.launch(Dispatchers.IO) {
             FirebaseCrashlytics.getInstance().recordException(throwable)
+        }
+    }
+
+    protected fun <T> execute(
+        action: suspend () -> Result<T>,
+        eventHandler: NetworkEventDelegate,
+        onSuccess: (T) -> Unit,
+    ) {
+        viewModelScope.launch(recordExceptionHandler){
+            eventHandler.event(viewModelScope, NetworkEvent.Loading)
+            action().onSuccess {
+                onSuccess(it)
+                eventHandler.event(viewModelScope, NetworkEvent.Success)
+            }.onError { throwable ->
+                eventHandler.event(
+                    viewModelScope,
+                    NetworkEvent.Error(eventHandler.asUiText(throwable))
+                )
+            }
         }
     }
 }

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/delegate/NetworkEventDelegate.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/delegate/NetworkEventDelegate.kt
@@ -1,0 +1,59 @@
+package kr.techit.lion.presentation.delegate
+
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.receiveAsFlow
+import kotlinx.coroutines.launch
+import kr.techit.lion.domain.exception.HttpError.ServerError
+import kr.techit.lion.domain.exception.HttpError.NotFoundError
+import kr.techit.lion.domain.exception.HttpError.AuthenticationError
+import kr.techit.lion.domain.exception.HttpError.AuthorizationError
+import kr.techit.lion.domain.exception.HttpError.BadRequestError
+import kr.techit.lion.domain.exception.NetworkError
+import kr.techit.lion.domain.exception.NetworkError.TimeoutError
+import kr.techit.lion.domain.exception.NetworkError.ConnectError
+import kr.techit.lion.domain.exception.NetworkError.UnknownError
+import kr.techit.lion.domain.exception.NetworkError.UnknownHostError
+import retrofit2.HttpException
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import java.util.concurrent.TimeoutException
+import javax.inject.Inject
+
+class NetworkEventDelegate @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private val _event = Channel<NetworkEvent>(Channel.BUFFERED)
+    val event = _event.receiveAsFlow()
+
+    fun submitThrowableEvent(scope: CoroutineScope, e: Throwable) {
+        when (e) {
+            is TimeoutException -> event(scope, NetworkEvent.Error(asUiText(TimeoutError)))
+            is UnknownHostException -> event(scope, NetworkEvent.Error(asUiText(UnknownHostError)))
+            is UnknownError -> event(scope, NetworkEvent.Error(asUiText(UnknownError)))
+            else -> event(scope, NetworkEvent.Error(asUiText(e)))
+        }
+    }
+
+    fun asUiText(exception: Throwable): String{
+        return UiTextProvider(context).asUiText(exception)
+    }
+
+    fun event(scope: CoroutineScope, event: NetworkEvent) {
+        scope.launch {
+            _event.send(event)
+        }
+    }
+}
+
+sealed class NetworkEvent{
+    data object Loading: NetworkEvent()
+    data object Success: NetworkEvent()
+    data class Error(val msg: String): NetworkEvent()
+}

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/delegate/UiTextProvider.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/delegate/UiTextProvider.kt
@@ -1,0 +1,50 @@
+package kr.techit.lion.presentation.delegate
+
+import android.content.Context
+import kr.techit.lion.domain.exception.HttpError
+import kr.techit.lion.domain.exception.NetworkError
+import kr.techit.lion.presentation.R
+
+class UiTextProvider(private val context: Context) {
+
+    fun asUiText(throwable: Throwable): String {
+        val error = throwable.toNetworkError()
+            ?: return context.getString(R.string.network_error_unknown_title)
+        return "${asTitle(error)}\n${asContent(error)}"
+    }
+
+    private fun Throwable.toNetworkError(): NetworkError? {
+        return when (this) {
+            is NetworkError -> this
+            else -> null
+        }
+    }
+
+    private fun asTitle(error: NetworkError): String {
+        return when (error) {
+            is NetworkError.ConnectError -> context.getString(R.string.network_error_connect_title)
+            is NetworkError.TimeoutError -> context.getString(R.string.network_error_timeout_title)
+            is NetworkError.UnknownHostError -> context.getString(R.string.network_error_unknown_host_title)
+            is NetworkError.UnknownError -> context.getString(R.string.network_error_unknown_title)
+            is HttpError.BadRequestError -> context.getString(R.string.http_error_bad_request_title)
+            is HttpError.AuthenticationError -> context.getString(R.string.http_error_authentication_title)
+            is HttpError.AuthorizationError -> context.getString(R.string.http_error_authorization_title)
+            is HttpError.NotFoundError -> context.getString(R.string.http_error_not_found_title)
+            is HttpError.ServerError -> context.getString(R.string.http_error_server_title)
+        }
+    }
+
+    private fun asContent(error: NetworkError): String {
+        return when (error) {
+            is NetworkError.ConnectError -> context.getString(R.string.network_error_connect_title)
+            is NetworkError.TimeoutError -> context.getString(R.string.network_error_timeout_message)
+            is NetworkError.UnknownHostError -> context.getString(R.string.network_error_unknown_host_message)
+            is NetworkError.UnknownError -> context.getString(R.string.network_error_unknown_message)
+            is HttpError.BadRequestError -> context.getString(R.string.http_error_bad_request_message)
+            is HttpError.AuthenticationError -> context.getString(R.string.http_error_authentication_message)
+            is HttpError.AuthorizationError -> context.getString(R.string.http_error_authorization_message)
+            is HttpError.NotFoundError -> context.getString(R.string.http_error_not_found_message)
+            is HttpError.ServerError -> context.getString(R.string.http_error_server_message)
+        }
+    }
+}

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/keyword/fragment/SearchResultFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/keyword/fragment/SearchResultFragment.kt
@@ -13,7 +13,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 import kr.techit.lion.presentation.R
 import kr.techit.lion.presentation.databinding.FragmentSearchResultBinding
-import kr.techit.lion.presentation.delegate.NetworkState
 import kr.techit.lion.presentation.ext.addOnScrollEndListener
 import kr.techit.lion.presentation.ext.hideSoftInput
 import kr.techit.lion.presentation.ext.repeatOnViewStarted
@@ -21,6 +20,7 @@ import kr.techit.lion.presentation.home.DetailActivity
 import kr.techit.lion.presentation.keyword.adapter.SearchResultAdapter
 import kr.techit.lion.presentation.keyword.vm.SearchResultViewModel
 import kr.techit.lion.presentation.connectivity.connectivity.ConnectivityStatus
+import kr.techit.lion.presentation.delegate.NetworkEvent
 
 @AndroidEntryPoint
 class SearchResultFragment : Fragment(R.layout.fragment_search_result) {
@@ -71,13 +71,13 @@ class SearchResultFragment : Fragment(R.layout.fragment_search_result) {
                 }
 
                 launch {
-                    combine(viewModel.networkState, viewModel.uiState) { networkState, uiState ->
-                        when (networkState) {
-                            is NetworkState.Loading -> {
+                    combine(viewModel.networkEvent, viewModel.uiState) { event, uiState ->
+                        when (event) {
+                            is NetworkEvent.Loading -> {
                                 progressBar.visibility = View.VISIBLE
                             }
 
-                            is NetworkState.Success -> {
+                            is NetworkEvent.Success -> {
                                 val place = uiState.place
                                 progressBar.visibility = View.GONE
                                 if (place.isEmpty()) {
@@ -90,8 +90,8 @@ class SearchResultFragment : Fragment(R.layout.fragment_search_result) {
                                 }
                             }
 
-                            is NetworkState.Error -> {
-                                showNetworkErrorPage(binding, progressBar, networkState.msg)
+                            is NetworkEvent.Error -> {
+                                showNetworkErrorPage(binding, progressBar, event.msg)
                             }
                         }
                     }.collect { }

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/login/fragment/SelectInterestFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/login/fragment/SelectInterestFragment.kt
@@ -13,7 +13,7 @@ import kr.techit.lion.domain.model.ConcernType
 import kr.techit.lion.domain.model.hasAnyTrue
 import kr.techit.lion.presentation.R
 import kr.techit.lion.presentation.databinding.FragmentSelectInterestBinding
-import kr.techit.lion.presentation.delegate.NetworkState
+import kr.techit.lion.presentation.delegate.NetworkEvent
 import kr.techit.lion.presentation.ext.isTallBackEnabled
 import kr.techit.lion.presentation.ext.repeatOnViewStarted
 import kr.techit.lion.presentation.login.model.InterestType
@@ -54,24 +54,24 @@ class SelectInterestFragment : Fragment(R.layout.fragment_select_interest) {
         }
 
         repeatOnViewStarted {
-            launch { collectNetworkState(binding) }
+            launch { collectNetworkEvent(binding) }
             launch { collectConcernType(binding) }
         }
     }
 
-    private suspend fun collectNetworkState(binding: FragmentSelectInterestBinding){
-        viewModel.networkState.collect {
-            when(it) {
-                is NetworkState.Loading -> return@collect
-                is NetworkState.Error -> {
-                    binding.btnRetry.visibility = View.VISIBLE
-                    binding.progressBar.visibility = View.GONE
-                    Snackbar.make(binding.root, getString(R.string.plz_retry), Snackbar.LENGTH_SHORT).show()
-                }
-                is NetworkState.Success -> {
+    private suspend fun collectNetworkEvent(binding: FragmentSelectInterestBinding){
+        viewModel.networkEvent.collect { event ->
+            when(event) {
+                NetworkEvent.Loading -> Unit
+                NetworkEvent.Success -> {
                     binding.progressBar.visibility = View.GONE
                     startActivity(Intent(requireActivity(), MainActivity::class.java))
                     requireActivity().finish()
+                }
+                is NetworkEvent.Error -> {
+                    binding.btnRetry.visibility = View.VISIBLE
+                    binding.progressBar.visibility = View.GONE
+                    Snackbar.make(binding.root, getString(R.string.plz_retry), Snackbar.LENGTH_SHORT).show()
                 }
             }
         }

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/login/vm/LoginViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/login/vm/LoginViewModel.kt
@@ -3,19 +3,14 @@ package kr.techit.lion.presentation.login.vm
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kr.techit.lion.domain.exception.onError
-import kr.techit.lion.domain.exception.onSuccess
 import kr.techit.lion.domain.model.ConcernType
 import kr.techit.lion.domain.model.hasAnyTrue
 import kr.techit.lion.domain.repository.AuthRepository
 import kr.techit.lion.domain.repository.MemberRepository
 import kr.techit.lion.presentation.base.BaseViewModel
-import kr.techit.lion.presentation.delegate.NetworkErrorDelegate
-import kr.techit.lion.presentation.delegate.NetworkState
+import kr.techit.lion.presentation.delegate.NetworkEventDelegate
 import kr.techit.lion.presentation.login.model.UserType
 import javax.inject.Inject
 
@@ -23,11 +18,10 @@ import javax.inject.Inject
 class LoginViewModel @Inject constructor(
     private val authRepository: AuthRepository,
     private val memberRepository: MemberRepository,
+    private val networkEventDelegate: NetworkEventDelegate
 ) : BaseViewModel() {
 
-    @Inject
-    lateinit var networkErrorDelegate: NetworkErrorDelegate
-    val networkState: StateFlow<NetworkState> get() = networkErrorDelegate.networkState
+    val networkEvent get() = networkEventDelegate.event
 
     private val _state = MutableStateFlow(UserType.Checking)
     val state get() = _state.asStateFlow()
@@ -39,17 +33,13 @@ class LoginViewModel @Inject constructor(
         }
     }
 
-    private fun checkUserState() {
-        viewModelScope.launch {
-            networkErrorDelegate.handleNetworkLoading()
-            memberRepository.getConcernType().onSuccess { type ->
-                modifyUserState(type)
-                networkErrorDelegate.handleNetworkSuccess()
-            }.onError {
-                networkErrorDelegate.handleNetworkError(it)
-            }
+    private fun checkUserState() = execute(
+        action = { memberRepository.getConcernType() },
+        eventHandler = networkEventDelegate,
+        onSuccess = { type ->
+            modifyUserState(type)
         }
-    }
+    )
 
     private fun modifyUserState(type: ConcernType) {
         if (type.hasAnyTrue()) {

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/main/myinfo/MyInfoMainFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/main/myinfo/MyInfoMainFragment.kt
@@ -18,6 +18,7 @@ import kr.techit.lion.presentation.bookmark.BookmarkActivity
 import kr.techit.lion.presentation.concerntype.ConcernTypeActivity
 import kr.techit.lion.presentation.connectivity.connectivity.ConnectivityStatus
 import kr.techit.lion.presentation.databinding.FragmentMyInfoMainBinding
+import kr.techit.lion.presentation.delegate.NetworkEvent
 import kr.techit.lion.presentation.delegate.NetworkState
 import kr.techit.lion.presentation.ext.announceForAccessibility
 import kr.techit.lion.presentation.ext.isTallBackEnabled
@@ -173,19 +174,18 @@ class MyInfoMainFragment : Fragment(R.layout.fragment_my_info_main) {
 
     private suspend fun handleNetworkState(binding: FragmentMyInfoMainBinding) {
         with(binding) {
-            viewModel.networkState.collect {
-                when (it) {
-                    NetworkState.Loading -> progressBar.visibility = View.VISIBLE
-                    NetworkState.Success -> {
+            viewModel.networkEvent.collect { event ->
+                when (event) {
+                    NetworkEvent.Loading -> progressBar.visibility = View.VISIBLE
+                    NetworkEvent.Success -> {
                         mainContainer.visibility = View.VISIBLE
                         progressBar.visibility = View.GONE
                         errorContainer.visibility = View.GONE
                     }
-
-                    is NetworkState.Error -> {
+                    is NetworkEvent.Error -> {
                         mainContainer.visibility = View.GONE
                         binding.progressBar.visibility = View.GONE
-                        showErrorPage(binding, it.msg)
+                        showErrorPage(binding, event.msg)
                     }
                 }
             }

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/main/search/SearchListFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/main/search/SearchListFragment.kt
@@ -13,6 +13,7 @@ import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.launch
 import kr.techit.lion.presentation.R
 import kr.techit.lion.presentation.databinding.FragmentSearchListBinding
+import kr.techit.lion.presentation.delegate.NetworkEvent
 import kr.techit.lion.presentation.delegate.NetworkState
 import kr.techit.lion.presentation.ext.addOnScrollEndListener
 import kr.techit.lion.presentation.ext.repeatOnViewStarted
@@ -115,24 +116,24 @@ class SearchListFragment : Fragment(R.layout.fragment_search_list) {
                 }
 
                 launch {
-                    viewModel.networkState.collect { networkState ->
-                        when (networkState) {
-                            is NetworkState.Loading -> {
+                    viewModel.networkEvent.collect { event ->
+                        when (event) {
+                            is NetworkEvent.Loading -> {
                                 searchListProgressBar.visibility = View.VISIBLE
                             }
 
-                            is NetworkState.Success -> {
+                            is NetworkEvent.Success -> {
                                 searchListProgressBar.visibility = View.GONE
                                 rvSearchResult.visibility = View.VISIBLE
                                 noSearchResultContainer.visibility = View.GONE
                                 searchListProgressBar.visibility = View.GONE
                             }
 
-                            is NetworkState.Error -> {
+                            is NetworkEvent.Error -> {
                                 searchListProgressBar.visibility = View.GONE
                                 rvSearchResult.visibility = View.GONE
                                 noSearchResultContainer.visibility = View.VISIBLE
-                                textMsg.text = networkState.msg
+                                textMsg.text = event.msg
                             }
                         }
                     }

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/main/search/vm/SearchMapViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/main/search/vm/SearchMapViewModel.kt
@@ -22,6 +22,8 @@ import kr.techit.lion.domain.exception.NetworkError.UnknownError
 import kr.techit.lion.domain.repository.PlaceRepository
 import kr.techit.lion.presentation.base.BaseViewModel
 import kr.techit.lion.presentation.delegate.NetworkErrorDelegate
+import kr.techit.lion.presentation.delegate.NetworkEvent
+import kr.techit.lion.presentation.delegate.NetworkEventDelegate
 import kr.techit.lion.presentation.main.search.vm.model.Category
 import kr.techit.lion.presentation.main.search.vm.model.DisabilityType
 import kr.techit.lion.presentation.main.search.vm.model.ElderlyPeople
@@ -38,15 +40,14 @@ import java.util.TreeSet
 import java.util.concurrent.TimeoutException
 import javax.inject.Inject
 
+@OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class SearchMapViewModel @Inject constructor(
     private val placeRepository: PlaceRepository,
-) : BaseViewModel(){
+    private val networkEventDelegate: NetworkEventDelegate
+) : BaseViewModel() {
 
-    @Inject
-    lateinit var networkErrorDelegate: NetworkErrorDelegate
-
-    val networkState get() = networkErrorDelegate.networkState
+    val networkEvent get() = networkEventDelegate.event
 
     private val _mapOptionState = MutableStateFlow(MapOptionState.create())
     val mapOptionState get() = _mapOptionState.asStateFlow()
@@ -54,47 +55,49 @@ class SearchMapViewModel @Inject constructor(
     private val _searchState = MutableSharedFlow<Boolean>()
     val searchState get() = _searchState.asSharedFlow()
 
-    @OptIn(FlowPreview::class, ExperimentalCoroutinesApi::class)
     val mapSearchResult = _mapOptionState
         .debounce(DEBOUNCE_INTERVAL)
         .flatMapLatest { request ->
             val response = placeRepository.getSearchPlaceResultByMap(request.toDomainModel())
-            networkErrorDelegate.handleNetworkSuccess()
+            networkEventDelegate.event(
+                scope = viewModelScope,
+                event = NetworkEvent.Success
+            )
             response.map {
                 if (it.places.isEmpty()) _searchState.emit(false)
                 it.toUiModel()
             }
         }.flowOn(recordExceptionHandler)
         .catch { e: Throwable ->
-            submitThrowableState(e)
+            networkEventDelegate.submitThrowableEvent(viewModelScope, e)
         }
 
     fun onSelectedTab(category: Category) {
-        networkErrorDelegate.handleNetworkLoading()
+        networkEventDelegate.event(viewModelScope, NetworkEvent.Loading)
 
         if (_mapOptionState.value.category != category) {
             _mapOptionState.update { it.copy(category = category) }
         }
     }
 
-    fun onCameraPositionChanged(locate: Locate){
-        networkErrorDelegate.handleNetworkLoading()
+    fun onCameraPositionChanged(locate: Locate) {
+        networkEventDelegate.event(viewModelScope, NetworkEvent.Loading)
 
         if (_mapOptionState.value.location != locate) {
             _mapOptionState.update { it.copy(location = locate) }
         }
     }
 
-    fun onChangeMapState(state: SharedOptionState){
-        networkErrorDelegate.handleNetworkLoading()
+    fun onChangeMapState(state: SharedOptionState) {
+        networkEventDelegate.event(viewModelScope, NetworkEvent.Loading)
 
         _mapOptionState.update {
-            if (state.detailFilter.isEmpty()){
+            if (state.detailFilter.isEmpty()) {
                 it.copy(
                     disabilityType = TreeSet(),
                     detailFilter = TreeSet()
                 )
-            }else{
+            } else {
                 it.copy(
                     disabilityType = state.disabilityType,
                     detailFilter = state.detailFilter
@@ -104,76 +107,45 @@ class SearchMapViewModel @Inject constructor(
     }
 
     fun onSelectOption(optionCodes: List<Long>, type: DisabilityType) {
-        networkErrorDelegate.handleNetworkLoading()
+        networkEventDelegate.event(viewModelScope, NetworkEvent.Loading)
 
         val currentOptionState = _mapOptionState.value
         val mapUpdatedTypes = TreeSet(currentOptionState.disabilityType)
         val mapUpdatedFilters = TreeSet(currentOptionState.detailFilter)
 
-        viewModelScope.launch {
-            when (type) {
-                is PhysicalDisability -> {
-                    mapUpdatedFilters.removeAll(PhysicalDisability.filterCodes)
-                }
+        when (type) {
+            is PhysicalDisability -> mapUpdatedFilters.removeAll(PhysicalDisability.filterCodes)
+            is VisualImpairment -> mapUpdatedFilters.removeAll(VisualImpairment.filterCodes)
+            is HearingImpairment -> mapUpdatedFilters.removeAll(HearingImpairment.filterCodes)
+            is InfantFamily -> mapUpdatedFilters.removeAll(InfantFamily.filterCodes)
+            is ElderlyPeople -> mapUpdatedFilters.removeAll(ElderlyPeople.filterCodes)
+        }
 
-                is VisualImpairment -> {
-                    mapUpdatedFilters.removeAll(VisualImpairment.filterCodes)
-                }
+        if (optionCodes.isNotEmpty()) {
+            mapUpdatedTypes.add(type.code)
+            mapUpdatedFilters.addAll(optionCodes)
+        } else {
+            mapUpdatedTypes.remove(type.code)
+        }
 
-                is HearingImpairment -> {
-                    mapUpdatedFilters.removeAll(HearingImpairment.filterCodes)
-                }
-
-                is InfantFamily -> {
-                    mapUpdatedFilters.removeAll(InfantFamily.filterCodes)
-                }
-
-                is ElderlyPeople -> {
-                    mapUpdatedFilters.removeAll(ElderlyPeople.filterCodes)
-                }
-            }
-
-            if (optionCodes.isNotEmpty()) {
-                mapUpdatedTypes.add(type.code)
-                mapUpdatedFilters.addAll(optionCodes)
-            } else {
-                mapUpdatedTypes.remove(type.code)
-            }
-
-            _mapOptionState.update {
-                _mapOptionState.value.copy(
-                    disabilityType = mapUpdatedTypes,
-                    detailFilter = mapUpdatedFilters,
-                )
-            }
+        _mapOptionState.update {
+            _mapOptionState.value.copy(
+                disabilityType = mapUpdatedTypes,
+                detailFilter = mapUpdatedFilters,
+            )
         }
     }
 
-    fun onClickRestButton(){
-        _mapOptionState.update { it.copy(
-            disabilityType = DisabilityType.createDisabilityTypeCodes(),
-            detailFilter = DisabilityType.createFilterCodes(),
-        ) }
-    }
-
-    private fun submitThrowableState(e: Throwable){
-        when (e) {
-            is TimeoutException ->{
-                networkErrorDelegate.handleNetworkError(TimeoutError)
-            }
-            is UnknownHostException -> {
-                networkErrorDelegate.handleNetworkError(UnknownHostError)
-            }
-            is UnknownError -> {
-                networkErrorDelegate.handleNetworkError(UnknownError)
-            }
-            else -> {
-                networkErrorDelegate.handleNetworkError(e as NetworkError)
-            }
+    fun onClickRestButton() {
+        _mapOptionState.update {
+            it.copy(
+                disabilityType = DisabilityType.createDisabilityTypeCodes(),
+                detailFilter = DisabilityType.createFilterCodes(),
+            )
         }
     }
 
-    companion object{
-        private const val DEBOUNCE_INTERVAL = 1500L
+    companion object {
+        private const val DEBOUNCE_INTERVAL = 1000L
     }
 }

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/main/search/vm/SearchMapViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/main/search/vm/SearchMapViewModel.kt
@@ -16,9 +16,9 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kr.techit.lion.domain.exception.NetworkError
-import kr.techit.lion.domain.exception.TimeoutError
-import kr.techit.lion.domain.exception.UnknownError
-import kr.techit.lion.domain.exception.UnknownHostError
+import kr.techit.lion.domain.exception.NetworkError.TimeoutError
+import kr.techit.lion.domain.exception.NetworkError.UnknownHostError
+import kr.techit.lion.domain.exception.NetworkError.UnknownError
 import kr.techit.lion.domain.repository.PlaceRepository
 import kr.techit.lion.presentation.base.BaseViewModel
 import kr.techit.lion.presentation.delegate.NetworkErrorDelegate

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/myinfo/DeleteUserActivity.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/myinfo/DeleteUserActivity.kt
@@ -5,7 +5,9 @@ import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import dagger.hilt.android.AndroidEntryPoint
+import kr.techit.lion.presentation.R
 import kr.techit.lion.presentation.databinding.ActivityDeleteUserBinding
+import kr.techit.lion.presentation.delegate.NetworkEvent
 import kr.techit.lion.presentation.delegate.NetworkState
 import kr.techit.lion.presentation.ext.repeatOnStarted
 import kr.techit.lion.presentation.ext.showInfinitySnackBar
@@ -31,9 +33,9 @@ class DeleteUserActivity : AppCompatActivity() {
 
             btnDelete.setOnClickListener {
                 val dialog = ConfirmDialog(
-                    "회원 탈퇴",
-                    "정말 회원을 탈퇴 하시겠습니까?",
-                    "탈퇴 하기"
+                    this@DeleteUserActivity.getString(R.string.text_member_withdrawal_title),
+                    this@DeleteUserActivity.getString(R.string.text_member_withdrawal_message),
+                    this@DeleteUserActivity.getString(R.string.text_member_withdrawal_confirm),
                 ) {
                     viewModel.withdrawal {
                         startActivity(Intent(this@DeleteUserActivity, LoginActivity::class.java))
@@ -45,15 +47,15 @@ class DeleteUserActivity : AppCompatActivity() {
             }
         }
         repeatOnStarted {
-            viewModel.networkState.collect { state ->
-                when (state) {
-                    is NetworkState.Loading -> return@collect
-                    is NetworkState.Success -> {
+            viewModel.networkEvent.collect { event ->
+                when (event) {
+                    NetworkEvent.Loading -> Unit
+                    NetworkEvent.Success -> {
                         startActivity(Intent(this@DeleteUserActivity, LoginActivity::class.java))
                         finish()
                     }
-                    is NetworkState.Error -> {
-                        showInfinitySnackBar(binding.root, state.msg)
+                    is NetworkEvent.Error -> {
+                        showInfinitySnackBar(binding.root, event.msg)
                     }
                 }
             }

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/myinfo/fragment/MyInfoFragment.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/myinfo/fragment/MyInfoFragment.kt
@@ -25,6 +25,7 @@ import kr.techit.lion.presentation.connectivity.ConnectivityObserver
 import kr.techit.lion.presentation.connectivity.NetworkConnectivityObserver
 import kr.techit.lion.domain.model.PersonalInfo
 import kr.techit.lion.domain.model.IceInfo
+import kr.techit.lion.presentation.delegate.NetworkEvent
 
 @AndroidEntryPoint
 class MyInfoFragment : Fragment(R.layout.fragment_my_info) {
@@ -232,10 +233,10 @@ class MyInfoFragment : Fragment(R.layout.fragment_my_info) {
 
     private suspend fun collectNetworkState(binding: FragmentMyInfoBinding) {
         with(binding) {
-            viewModel.networkState.collect {
-                when (it) {
-                    is NetworkState.Loading -> progressBar.visibility = View.VISIBLE
-                    is NetworkState.Success -> {
+            viewModel.networkEvent.collect { event ->
+                when (event) {
+                    NetworkEvent.Loading -> progressBar.visibility = View.VISIBLE
+                    NetworkEvent.Success -> {
                         progressBar.visibility = View.GONE
                         errorContainer.visibility = View.GONE
                         mainContainer.visibility = View.VISIBLE
@@ -244,13 +245,13 @@ class MyInfoFragment : Fragment(R.layout.fragment_my_info) {
                         }
                     }
 
-                    is NetworkState.Error -> {
+                    is NetworkEvent.Error -> {
                         progressBar.visibility = View.GONE
                         mainContainer.visibility = View.GONE
                         errorContainer.visibility = View.VISIBLE
-                        textMsg.text = it.msg
+                        textMsg.text = event.msg
                         if (requireContext().isTallBackEnabled()) {
-                            requireActivity().announceForAccessibility(it.msg)
+                            requireActivity().announceForAccessibility(event.msg)
                         }
                     }
                 }

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/myinfo/vm/DeleteUserViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/myinfo/vm/DeleteUserViewModel.kt
@@ -8,26 +8,27 @@ import kr.techit.lion.domain.exception.onSuccess
 import kr.techit.lion.domain.repository.AuthRepository
 import kr.techit.lion.presentation.base.BaseViewModel
 import kr.techit.lion.presentation.delegate.NetworkErrorDelegate
+import kr.techit.lion.presentation.delegate.NetworkEventDelegate
 import javax.inject.Inject
 
 @HiltViewModel
 class DeleteUserViewModel @Inject constructor(
-    private val authRepository: AuthRepository
+    private val authRepository: AuthRepository,
+    private val networkEventDelegate: NetworkEventDelegate
 ): BaseViewModel() {
 
     @Inject
     lateinit var networkErrorDelegate: NetworkErrorDelegate
 
-    val networkState get() = networkErrorDelegate.networkState
+    val networkEvent get() = networkEventDelegate.event
 
     fun withdrawal(action: () -> Unit){
-        viewModelScope.launch(recordExceptionHandler) {
-            authRepository.withdraw()
-            .onSuccess {
+        execute(
+            action = { authRepository.withdraw() },
+            eventHandler = networkEventDelegate,
+            onSuccess = {
                 action()
-            }.onError { e ->
-                networkErrorDelegate.handleNetworkError(e)
             }
-        }
+        )
     }
 }

--- a/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/splash/vm/SplashViewModel.kt
+++ b/DaOnGil/presentation/src/main/java/kr/techit/lion/presentation/splash/vm/SplashViewModel.kt
@@ -3,37 +3,36 @@ package kr.techit.lion.presentation.splash.vm
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.shareIn
-import kotlinx.coroutines.flow.stateIn
 import kr.techit.lion.domain.model.Activation
 import kr.techit.lion.domain.repository.ActivationRepository
 import kr.techit.lion.domain.usecase.areacode.InitAreaCodeInfoUseCase
 import kr.techit.lion.domain.usecase.base.onError
 import kr.techit.lion.domain.usecase.base.onSuccess
+import kr.techit.lion.presentation.delegate.NetworkEvent
+import kr.techit.lion.presentation.delegate.NetworkEventDelegate
 import kr.techit.lion.presentation.ext.stateInUi
 import javax.inject.Inject
 
 @HiltViewModel
 class SplashViewModel @Inject constructor(
-    private val activationRepository: ActivationRepository,
+    activationRepository: ActivationRepository,
     private val initAreaCodeInfoUseCase: InitAreaCodeInfoUseCase,
-): ViewModel() {
+    private val networkEventDelegate: NetworkEventDelegate
+) : ViewModel() {
 
-    private val _errorState = MutableStateFlow(false)
-    val errorState get() = _errorState.asStateFlow()
+    val networkEvent = networkEventDelegate.event
 
     val userActivationState = activationRepository
         .activation
         .stateInUi(scope = viewModelScope, initialValue = Activation.Loading)
 
-    suspend fun whenUserActivationIsDeActivate(onComplete: () -> Unit){
-        initAreaCodeInfoUseCase().onSuccess {
-            onComplete()
-        }.onError {
-            _errorState.value = true
-        }
+    suspend fun whenUserActivationIsDeActivate() {
+        initAreaCodeInfoUseCase()
+            .onSuccess {
+                networkEventDelegate.event(viewModelScope, NetworkEvent.Success)
+            }
+            .onError { exception ->
+                networkEventDelegate.submitThrowableEvent(viewModelScope, exception)
+            }
     }
 }

--- a/DaOnGil/presentation/src/main/res/values/strings.xml
+++ b/DaOnGil/presentation/src/main/res/values/strings.xml
@@ -436,4 +436,38 @@
     <string name="text_ask_remove_recently_search_keyword">최근 검색어를 모두\n삭제하시겠습니까?</string>
     <string name="text_remove_keyword">삭제하기</string>
     <string name="text_no_search_result">검색 결과가 없어요.\n 다른 검색어를 입력해주세요</string>
+
+    <string name="text_member_withdrawal_title">회원 탈퇴</string>
+    <string name="text_member_withdrawal_message">정말 회원을 탈퇴 하시겠습니까?</string>
+    <string name="text_member_withdrawal_confirm">탈퇴 하기</string>
+
+    <!-- General Network Errors -->
+    <string name="network_error_connect_title">서버에 연결할 수 없어요</string>
+    <string name="network_error_connect_message">인터넷 연결을 확인한 후 다시 시도해주세요.</string>
+
+    <string name="network_error_timeout_title">서버 응답 시간이 초과되었어요</string>
+    <string name="network_error_timeout_message">잠시 후 다시 시도해주세요.</string>
+
+    <string name="network_error_unknown_host_title">서버를 찾을 수 없습니다.</string>
+    <string name="network_error_unknown_host_message">인터넷 연결 상태를 확인해주세요.</string>
+
+    <string name="network_error_unknown_title">알 수 없는 오류가 발생했어요</string>
+    <string name="network_error_unknown_message">잠시 후 다시 시도해주세요.</string>
+
+    <!-- HTTP Errors -->
+    <string name="http_error_bad_request_title">인증 오류가 발생했어요</string>
+    <string name="http_error_bad_request_message">요청 내용을 확인하고 다시 시도해주세요.</string>
+
+    <string name="http_error_authentication_title">로그인 문제가 발생했습니다.</string>
+    <string name="http_error_authentication_message">문제가 반복 된다면 다시 로그인해주세요.</string>
+
+    <string name="http_error_authorization_title">서비스 이용 권한에 문제가 발생했습니다.</string>
+    <string name="http_error_authorization_message">해당 서비스에 대한 유저 권한이 없어요.</string>
+
+    <string name="http_error_not_found_title">해당 서비스를 찾을 수 없어요</string>
+    <string name="http_error_not_found_message">요청하신 페이지 또는 정보가 존재하지 않습니다.</string>
+
+    <string name="http_error_server_title">서버에 오류가 발생했어요</string>
+    <string name="http_error_server_message">잠시후 다시 시도해주세요.</string>
 </resources>
+


### PR DESCRIPTION
## #️⃣연관된 이슈

- #321

## 📝작업 내용

- 네트워크 에러 처리 수정

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)


## 💬리뷰 요구사항(선택)
### 수정사항 1
Domain Layer가 가지고 있던 에러 메시지를 Presentation Layer이 가지도록 수정했습니다.
개인적으로 항상 "에러가 발생했을 때 출력할 메시지를 정의한다" 라는 개념을 도메인 규칙으로 생각했습니다.

이 부분은 항상 강하게 주장해왔던 부분이라 성규님이 네트워크 메시지는 도메인이 가질 책임이 아니라고 
하셨을 때도 말씀하실 때도 안들었는데 ㅎㅎ

결론적으로 로컬라이징을 위해 에러 메시지들을 strings.xml 파일이 가지도록 하는게 맞다고 생각했습니다.

[참고자료](https://medium.com/@mangbaam/android-uitext-%EB%8B%A4%EC%96%91%ED%95%9C-%ED%98%95%ED%83%9C%EC%9D%98-%EB%AC%B8%EC%9E%90%EC%97%B4-%EC%B2%98%EB%A6%AC%ED%95%98%EA%B8%B0-08231e7f1ddf)


### 수정사항 2
기존 StateFlow로 구현된 네트워크 이벤트를 Channel로 수정했습니다.
StateFlow는 중복된 값을 방출하지 않는 다는 점에서
북마크, 좋아요 버튼 같은 반복적으로 발생할 수 있는 이벤트에 대해 에러 발생시 동일한 에러 이벤트를 처리할 수 없었습니다.

그래서 SharedFlow로 수정할지 고민했는데요, 최근 다음 [아티클](https://medium.com/prnd/mvvm%EC%9D%98-viewmodel%EC%97%90%EC%84%9C-%EC%9D%B4%EB%B2%A4%ED%8A%B8%EB%A5%BC-%EC%B2%98%EB%A6%AC%ED%95%98%EB%8A%94-%EB%B0%A9%EB%B2%95-6%EA%B0%80%EC%A7%80-31bb183a88ce)을 보게되었습니다.

해당 아티클에서 제시하는 sharedFlow의 문제는 
아이템 클릭 -> 서버 응답에 따른 에러 이벤트 발생 이전 앱이 백그라운드로 내려감 ->
에러 이벤트는 발생했지만 앱이 백그라운드로 내려갔기 때문에 이를 소비하는 곳이 없기 때문에
(앱이 백그라운드로 내려가면 값을 수집할 필요가 없기 때문)
(repeatOnStarted 확장 함수를 사용해 OnStart()/onStop()일 때만 값을 수집하도록 함)
이벤트가 유실됩니다.

그래서 해당 아티클에선 eventFlow라는 형태로 이벤트가 소비되지 않았다면 이를 계속 홀딩하도록 했는데요
엊그제 발표된 [아티클](https://medium.com/prnd/viewmodel%EC%97%90%EC%84%9C-%EB%8D%94%EC%9D%B4%EC%83%81-eventflow%EB%A5%BC-%EC%82%AC%EC%9A%A9%ED%95%98%EC%A7%80-%EB%A7%88%EC%84%B8%EC%9A%94-3974e8ddffed)에선 eventFlow의 기능을 대체할 수 있어 channel을 사용할 것을 제시해 사용했습니다.
