### PR TITLE
[#332] 응급지원 화면 접근성 기능 구현

### DIFF
--- a/presentation/src/main/java/kr/techit/lion/presentation/main/emergency/EmergencyMainFragment.kt
+++ b/presentation/src/main/java/kr/techit/lion/presentation/main/emergency/EmergencyMainFragment.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.View
-import kotlinx.coroutines.launch
 import kr.techit.lion.presentation.R
 import kr.techit.lion.presentation.databinding.FragmentEmergencyMainBinding
 import kr.techit.lion.presentation.emergency.EmergencyMapActivity
@@ -12,6 +11,8 @@ import kr.techit.lion.presentation.emergency.PharmacyMapActivity
 import kr.techit.lion.presentation.ext.repeatOnViewStarted
 import kr.techit.lion.presentation.connectivity.ConnectivityObserver
 import kr.techit.lion.presentation.connectivity.NetworkConnectivityObserver
+import kr.techit.lion.presentation.ext.announceForAccessibility
+import kr.techit.lion.presentation.ext.isTallBackEnabled
 
 class EmergencyMainFragment : Fragment(R.layout.fragment_emergency_main) {
 
@@ -34,6 +35,8 @@ class EmergencyMainFragment : Fragment(R.layout.fragment_emergency_main) {
             val intent = Intent(requireActivity(), PharmacyMapActivity::class.java)
             startActivity(intent)
         }
+
+        initializeAccessibility(binding)
 
         repeatOnViewStarted {
             observeConnectivity(binding)
@@ -61,6 +64,32 @@ class EmergencyMainFragment : Fragment(R.layout.fragment_emergency_main) {
                         emergencyMainErrorMsg.text = msg
                     }
                 }
+            }
+        }
+    }
+
+    private fun initializeAccessibility(binding: FragmentEmergencyMainBinding) {
+        if (requireContext().isTallBackEnabled()) {
+            setupAccessibility(binding)
+        } else {
+            binding.toolbarEmerMain.menu.clear()
+        }
+    }
+
+    private fun setupAccessibility(binding: FragmentEmergencyMainBinding) {
+        requireActivity().announceForAccessibility(
+            getString(R.string.text_script_this_is_emergency) +
+                    getString(R.string.text_script_read_all_text)
+        )
+
+        binding.toolbarEmerMain.setOnMenuItemClickListener {
+            when (it.itemId) {
+                R.id.read_script -> {
+                    requireActivity().announceForAccessibility(getString(R.string.text_script_guide_for_emergency))
+                    true
+                }
+
+                else -> false
             }
         }
     }

--- a/presentation/src/main/res/layout/fragment_emergency_main.xml
+++ b/presentation/src/main/res/layout/fragment_emergency_main.xml
@@ -10,18 +10,19 @@
         android:id="@+id/toolbarEmerMain"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingStart="@dimen/margin_basic">
+        android:paddingStart="@dimen/margin_basic"
+        app:menu="@menu/menu_read_script">
 
         <ImageView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:src="@drawable/toolbar_clover_icon"/>
+            android:src="@drawable/toolbar_clover_icon" />
 
         <TextView
+            style="@style/Theme.Toolbar.Main.Title"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="@dimen/margin_small1"
-            style="@style/Theme.Toolbar.Main.Title"/>
+            android:layout_marginStart="@dimen/margin_small1" />
 
     </com.google.android.material.appbar.MaterialToolbar>
 

--- a/presentation/src/main/res/values/strings.xml
+++ b/presentation/src/main/res/values/strings.xml
@@ -341,6 +341,17 @@
         화면 오른쪽 하단에는 일정 추가 버튼이 있습니다.
         이 버튼을 클릭하면 새로운 여행 일정을 만들 수 있습니다.
     </string>
+    <string name="text_script_this_is_emergency">
+        응급지원화면입니다.
+    </string>
+    <string name="text_script_guide_for_emergency">
+        응급 지원 화면은 내 주변 응급실과 제세동기, 약국을 찾을 수 있는 화면입니다.
+        화면 중앙에는 두 가지 버튼이 수직으로 정렬되어 있습니다.
+        첫 번째 버튼은 응급실과 제세동기 찾기 입니다.
+        해당 버튼을 클릭하면 내 주변 응급실과 제세동기 위치를 지도에 띄워 알려드립니다.
+        두 번째 버튼은 근처 약국 찾기 입니다.
+        해당 버튼을 클릭하면 내 주변 약국의 위치를 지도에 띄워 알려드립니다.
+    </string>
 
     <string name="text_read_all">모든 내용 읽기</string>
     <string name="text_read_screen_info">화면정보읽기</string>


### PR DESCRIPTION
## #️⃣연관된 이슈

- #332 

## 📝작업 내용

- 응급지원 화면에 Talkback 화면정보읽기 기능 구현

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)

| TalkBack 기능 OFF | TalkBack 기능 ON |
|-----|-----|
| <img width="300" alt="응급지원1" src="https://github.com/user-attachments/assets/94e842c4-7066-4152-84ab-d8225b005e40" /> | <img width="300" alt="응급지원2" src="https://github.com/user-attachments/assets/b29fcb47-52e8-49fc-ad63-33e2fa7f03b4" /> | 


- 응급지원 화면 진입 시 TalkBack
응급지원 화면 진입할 때마다 해당 멘트가 나옵니다.


https://github.com/user-attachments/assets/28f0b4c8-c758-4d2f-be45-2561eaeafc5f



- 화면정보읽기 버튼 클릭 시 TalkBack
영상이 길어서 잘라서 올립니다!


https://github.com/user-attachments/assets/ea5d655b-15b6-49ba-ab3e-3afed8a6e7f8



## 💬리뷰 요구사항(선택)

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
  - ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요
