### PR TITLE
[#330] 관광지 상세보기 네이버 지도 연결

### DIFF
--- a/data/src/main/java/kr/techit/lion/data/di/NetworkModule.kt
+++ b/data/src/main/java/kr/techit/lion/data/di/NetworkModule.kt
@@ -78,7 +78,7 @@ internal object NetworkModule {
     @Provides
     fun provideKorWithService(okHttpClient: OkHttpClient): KorWithService =
         Retrofit.Builder()
-            .baseUrl("https://apis.data.go.kr/B551011/KorWithService1/")
+            .baseUrl("https://apis.data.go.kr/B551011/KorWithService2/")
             .addConverterFactory(MoshiConverterFactory.create().asLenient())
             .client(okHttpClient)
             .build()

--- a/data/src/main/java/kr/techit/lion/data/service/KorWithService.kt
+++ b/data/src/main/java/kr/techit/lion/data/service/KorWithService.kt
@@ -5,7 +5,7 @@ import retrofit2.http.GET
 import retrofit2.http.QueryMap
 
 internal interface KorWithService {
-    @GET("areaCode1")
+    @GET("areaCode2")
     suspend fun getAreaCode(
         @QueryMap params: Map<String, String>
     ): AreaCodeResponse

--- a/presentation/src/main/java/kr/techit/lion/presentation/home/DetailActivity.kt
+++ b/presentation/src/main/java/kr/techit/lion/presentation/home/DetailActivity.kt
@@ -1,5 +1,6 @@
 package kr.techit.lion.presentation.home
 
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
@@ -10,6 +11,7 @@ import androidx.annotation.ColorRes
 import androidx.annotation.UiThread
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat
+import androidx.core.net.toUri
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.bumptech.glide.Glide
 import com.google.android.gms.location.FusedLocationProviderClient
@@ -28,6 +30,8 @@ import kotlinx.coroutines.launch
 import kr.techit.lion.domain.model.detailplace.Review
 import kr.techit.lion.domain.model.detailplace.SubDisability
 import kr.techit.lion.presentation.R
+import kr.techit.lion.presentation.connectivity.ConnectivityObserver
+import kr.techit.lion.presentation.connectivity.NetworkConnectivityObserver
 import kr.techit.lion.presentation.databinding.ActivityDetailBinding
 import kr.techit.lion.presentation.delegate.NetworkState
 import kr.techit.lion.presentation.emergency.EmergencyMapActivity
@@ -40,9 +44,8 @@ import kr.techit.lion.presentation.home.adapter.DetailReviewRVAdapter
 import kr.techit.lion.presentation.home.model.toReviewInfo
 import kr.techit.lion.presentation.home.vm.DetailViewModel
 import kr.techit.lion.presentation.myreview.MyReviewActivity
-import kr.techit.lion.presentation.connectivity.ConnectivityObserver
-import kr.techit.lion.presentation.connectivity.NetworkConnectivityObserver
 import kr.techit.lion.presentation.splash.model.LogInStatus
+import java.net.URLEncoder
 
 @AndroidEntryPoint
 class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
@@ -65,6 +68,10 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
                 }
             }
         }
+
+    companion object {
+        private const val NMAP_PACKAGE_NAME = "com.nhn.android.nmap"
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -225,6 +232,31 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
         naverMap.moveCamera(cameraUpdate)
 
         addMapMarker(longitude, latitude)
+
+        setOnMapClickListener(name, longitude, latitude)
+
+    }
+
+    private fun setOnMapClickListener(name: String, longitude: Double, latitude: Double) {
+        naverMap.setOnMapClickListener { pointF, latLng ->
+            val encodedName = URLEncoder.encode(name, "UTF-8")
+            val url = "nmap://place?lat=${longitude}&lng=${latitude}&name=${encodedName}&appname=${packageName}"
+            val uri = url.toUri()
+            val intent = Intent(Intent.ACTION_VIEW, uri).apply {
+                setPackage(NMAP_PACKAGE_NAME)
+            }
+
+            try {
+                startActivity(intent)
+            } catch (e: ActivityNotFoundException) {
+                startActivity(
+                    Intent(
+                        Intent.ACTION_VIEW,
+                        "market://details?id=${NMAP_PACKAGE_NAME}".toUri()
+                    )
+                )
+            }
+        }
     }
 
     private fun getDetailPlaceInfo(placeId: Long) {

--- a/presentation/src/main/java/kr/techit/lion/presentation/home/DetailActivity.kt
+++ b/presentation/src/main/java/kr/techit/lion/presentation/home/DetailActivity.kt
@@ -364,8 +364,8 @@ class DetailActivity : AppCompatActivity(), OnMapReadyCallback {
             position = LatLng(mapX, mapY)
             zIndex = 0
             map = naverMap
-            width = 86
-            height = 90
+            width = 91.38.toInt()
+            height = 114
         }
     }
 

--- a/presentation/src/main/res/layout/activity_detail.xml
+++ b/presentation/src/main/res/layout/activity_detail.xml
@@ -175,7 +175,7 @@
                 <FrameLayout
                     android:id="@+id/detail_map_layout"
                     android:layout_width="match_parent"
-                    android:layout_height="180dp"
+                    android:layout_height="220dp"
                     android:layout_marginHorizontal="@dimen/margin_basic"
                     android:layout_marginTop="@dimen/margin_big3"
                     app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
## #️⃣연관된 이슈

- #330 

## 📝작업 내용
- 지도, 마커 크기도 피그마, 비율 맞게 다시 조정해보았습니다~
- 관광지 상세보기에서 네이버 지도 연결했습니다!
    - 지도 클릭하면 네이버 지도로 이동하게됩니다~
    - 네이버 지도 설치되어있지 않으면 네이버 지도 설치 구글플레이스토어로 이동합니다!

## PR 발행 전 체크 리스트

- [x] 발행자 확인
- [x] 프로젝트 설정 확인
- [x] 라벨 확인

## 스크린샷 (선택)
- 네이버 지도 미설치

https://github.com/user-attachments/assets/41ef1c2b-a941-4a34-a4dc-8d336abffe43

- 네이버 지도 설치

https://github.com/user-attachments/assets/9dd9be24-401f-4dfa-943c-77b3f04d724e



## 💬리뷰 요구사항(선택)

- 방법대로 했는데... 네이버 지도 설치했는데도 자꾸 에러나고 구글플레이스토어 네이버지도 설치창으로 가서 당황했지만... 다행히 성공... 코드는 짧아서... 바쁜 지쿵 락스타보다 더 한게 없는 것 같네요 ㅠㅠ 송구합니다
